### PR TITLE
v0.0.5

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,12 +1,23 @@
+# v0.0.5
+
+* Add ability to specify query defaults.
+   * `defaultResultSize` -  the default number of results to return from a query
+   * `maxResultsSize` -  the maximum number of results to return from a query
+   * `defaultSort` -  The default sort to apply to queries
+   * `defaultFilter` -  The default filter to apply to queries
+
+# v0.0.4
+
+* Add files field to `@nestjs-query/core` `package.json`
+
 # v0.0.3
 
-* Fix package readmes
+* Fix package READMEs
 * Add security scanning on sub modules.
 
 # v0.0.2
 
 * Add MIT license
-
 
 # v0.0.1
 

--- a/documentation/blog/2020-01-27-v0.0.2.md
+++ b/documentation/blog/2020-01-27-v0.0.2.md
@@ -1,0 +1,13 @@
+---
+id: v0.0.2
+title: v0.0.2
+author: Doug Martin
+author_title: Creator
+author_url: https://github.com/doug-martin
+author_image_url: https://avatars1.githubusercontent.com/u/361261?v=4
+tags: [releases, patch]
+---
+
+* Add MIT license
+
+

--- a/documentation/blog/2020-01-27-v0.0.3.md
+++ b/documentation/blog/2020-01-27-v0.0.3.md
@@ -1,0 +1,15 @@
+---
+id: v0.0.3
+title: v0.0.3
+author: Doug Martin
+author_title: Creator
+author_url: https://github.com/doug-martin
+author_image_url: https://avatars1.githubusercontent.com/u/361261?v=4
+tags: [releases, patch]
+---
+
+* Fix package READMEs
+* Add security scanning on sub modules.
+
+
+

--- a/documentation/blog/2020-01-27-v0.0.4.md
+++ b/documentation/blog/2020-01-27-v0.0.4.md
@@ -1,0 +1,14 @@
+---
+id: v0.0.4
+title: v0.0.4
+author: Doug Martin
+author_title: Creator
+author_url: https://github.com/doug-martin
+author_image_url: https://avatars1.githubusercontent.com/u/361261?v=4
+tags: [releases, patch]
+---
+
+* Add files field to `@nestjs-query/core` `package.json`
+
+
+

--- a/documentation/blog/2020-01-28-v0.0.5.md
+++ b/documentation/blog/2020-01-28-v0.0.5.md
@@ -1,0 +1,18 @@
+---
+id: v0.0.5
+title: v0.0.5
+author: Doug Martin
+author_title: Creator
+author_url: https://github.com/doug-martin
+author_image_url: https://avatars1.githubusercontent.com/u/361261?v=4
+tags: [releases, patch]
+---
+
+* Add ability to specify query defaults.
+   * `defaultResultSize` -  the default number of results to return from a query. [See Default Paging](docs/graphql/resolvers#default-paging)
+   * `maxResultsSize` -  the maximum number of results to return from a query. [See Default Paging](docs/graphql/resolvers#default-paging)
+   * `defaultSort` -  The default sort to apply to queries. [See Default Sort](docs/graphql/resolvers#default-sort)
+   * `defaultFilter` -  The default filter to apply to queries. [See Default Filter](docs/graphql/resolvers#default-filter)
+
+
+

--- a/documentation/docs/graphql/resolvers.mdx
+++ b/documentation/docs/graphql/resolvers.mdx
@@ -62,6 +62,10 @@ The Crud Resolver accepts a number of options to control your endpoints.
 * `read` - In addition to [`ResolverOptions`](#resolveroptions) you can also specify the following
     * `QueryArgs` - The `ArgsType` to use to filter records in `queryMany` endpoint.
     * `Connection` - The `ObjectType` to return from the `queryMany` endpoint.
+    * `defaultResultSize=10` - The default number of results to return
+    * `maxResultsSize=50` - The maximum number of results an end user can specify to return from a query.
+    * `defaultSort=[]` - The default sort to use when querying for records.
+    * `defaultFilter={}` - The default filter to use when querying for records.
 
 * `update` - In addition to [`ResolverOptions`](#resolveroptions) you can also specify the following
     * `UpdateDTOClass` - The input DTO to use for update mutations.
@@ -284,6 +288,79 @@ export class TodoItemResolver extends CRUDResolver(TodoItemDTO, {
 }
 ```
 ---
+
+### Default Filter
+
+When querying the default filter is empty. You can specify a default filter by using the `read.defaultFilter` option.
+
+In this example we specify the default filter to be `completed IS TRUE`.
+
+```ts
+import { CRUDResolver } from '@nestjs-query/query-graphql';
+import { Resolver } from '@nestjs/graphql';
+import { TodoItemDTO } from './dto/todo-item.dto';
+import { TodoItemService } from './todo-item.service';
+
+@Resolver()
+export class TodoItemResolver extends CRUDResolver(TodoItemDTO, {
+  read: { defaultFilter: { completed: { is: true } } },
+}) {
+  constructor(readonly service: TodoItemService) {
+    super(service);
+  }
+}
+```
+---
+
+### Default Paging
+
+By default all results will be limited to 10 records, with a max of 50 records returned.
+
+To override the default you can override the following options:
+
+* `read.defaultResultSize` - The default number of results to return.
+* `read.maxResultSize` - The maximum number of results an end user can specify to return.
+
+In this example we specify the `defaultResultSize` to 5 and `maxResultsSize` to 20.
+
+```ts
+import { CRUDResolver } from '@nestjs-query/query-graphql';
+import { Resolver } from '@nestjs/graphql';
+import { TodoItemDTO } from './dto/todo-item.dto';
+import { TodoItemService } from './todo-item.service';
+
+@Resolver()
+export class TodoItemResolver extends CRUDResolver(TodoItemDTO, {
+  read: { defaultResultSize: 5, maxResultsSize: 20 },
+}) {
+  constructor(readonly service: TodoItemService) {
+    super(service);
+  }
+}
+```
+---
+
+### Default Sort
+
+When querying the default sort is based on the persistence layer. You can override the default by providing the `defaultSort` option.
+
+In this example we specify the default sort to be by `title`.
+
+```ts
+import { CRUDResolver } from '@nestjs-query/query-graphql';
+import { Resolver } from '@nestjs/graphql';
+import { TodoItemDTO } from './dto/todo-item.dto';
+import { TodoItemService } from './todo-item.service';
+
+@Resolver()
+export class TodoItemResolver extends CRUDResolver(TodoItemDTO, {
+  read: { defaultSort: [{ field: 'title', direction: SortDirection.ASC }] },
+}) {
+  constructor(readonly service: TodoItemService) {
+    super(service);
+  }
+}
+```
 
 ## Individual Resolvers
 

--- a/examples/nest-graphql-typeorm/src/todo-item/todo-item.resolver.ts
+++ b/examples/nest-graphql-typeorm/src/todo-item/todo-item.resolver.ts
@@ -1,6 +1,6 @@
 import { Filter } from '@nestjs-query/core';
-import { CRUDResolver, ConnectionType } from '@nestjs-query/query-graphql';
-import { Resolver, Args, Query } from '@nestjs/graphql';
+import { ConnectionType, CRUDResolver } from '@nestjs-query/query-graphql';
+import { Args, Query, Resolver } from '@nestjs/graphql';
 import { AuthGuard } from '../auth.guard';
 import { TodoItemDTO } from './dto/todo-item.dto';
 import { TodoItemService } from './todo-item.service';
@@ -10,6 +10,7 @@ const guards = [AuthGuard];
 
 @Resolver()
 export class TodoItemResolver extends CRUDResolver(TodoItemDTO, {
+  read: { defaultFilter: { completed: { is: true } } },
   create: { guards },
   update: { guards },
   delete: { guards },

--- a/examples/nest-graphql-typeorm/src/todo-item/types.ts
+++ b/examples/nest-graphql-typeorm/src/todo-item/types.ts
@@ -5,4 +5,4 @@ import { TodoItemDTO } from './dto/todo-item.dto';
 export const TodoItemConnection = ConnectionType(TodoItemDTO);
 
 @ArgsType()
-export class TodoItemQuery extends QueryArgsType(TodoItemDTO) {}
+export class TodoItemQuery extends QueryArgsType(TodoItemDTO, { defaultResultSize: 2 }) {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2582,14 +2582,6 @@
         "@types/lodash": "*"
       }
     },
-    "@types/lodash.pick": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.pick/-/lodash.pick-4.4.6.tgz",
-      "integrity": "sha512-u8bzA16qQ+8dY280z3aK7PoWb3fzX5ATJ0rJB6F+uqchOX2VYF02Aqa+8aYiHiHgPzQiITqCgeimlyKFy4OA6g==",
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",

--- a/packages/query-graphql/__tests__/resolvers/read.resolver.spec.ts
+++ b/packages/query-graphql/__tests__/resolvers/read.resolver.spec.ts
@@ -86,9 +86,10 @@ describe('ReadResolver', () => {
     it('should not create a new type if the Connection is supplied', () => {
       const Connection = ConnectionType(TestResolverDTO);
       jest.clearAllMocks(); // reset
-      ReadResolver(TestResolverDTO, { Connection });
+      const opts = { Connection };
+      ReadResolver(TestResolverDTO, opts);
 
-      expect(queryArgsTypeSpy).toBeCalledWith(TestResolverDTO);
+      expect(queryArgsTypeSpy).toBeCalledWith(TestResolverDTO, opts);
       expect(connectionTypeSpy).not.toBeCalled();
 
       expect(resolverQuerySpy).toBeCalledTimes(2);
@@ -107,7 +108,7 @@ describe('ReadResolver', () => {
         pipes: [],
       };
       ReadResolver(TestResolverDTO, { many: queryOpts });
-      expect(queryArgsTypeSpy).toBeCalledWith(TestResolverDTO);
+      expect(queryArgsTypeSpy).toBeCalledWith(TestResolverDTO, { many: queryOpts });
       expect(connectionTypeSpy).toBeCalledWith(TestResolverDTO);
       const Connection = connectionTypeSpy.mock.results[0].value;
 
@@ -164,7 +165,7 @@ describe('ReadResolver', () => {
         pipes: [],
       };
       ReadResolver(TestResolverDTO, { one: findById });
-      expect(queryArgsTypeSpy).toBeCalledWith(TestResolverDTO);
+      expect(queryArgsTypeSpy).toBeCalledWith(TestResolverDTO, { one: findById });
       expect(connectionTypeSpy).toBeCalledWith(TestResolverDTO);
       const Connection = connectionTypeSpy.mock.results[0].value;
 

--- a/packages/query-graphql/package.json
+++ b/packages/query-graphql/package.json
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "@nestjs-query/core": "^0.0.4",
-    "@types/lodash.pick": "^4.4.6",
     "change-case": "^3.1.0",
     "lodash.omit": "^4.4.0",
     "pluralize": "^8.0.0"

--- a/packages/query-graphql/src/resolvers/read.resolver.ts
+++ b/packages/query-graphql/src/resolvers/read.resolver.ts
@@ -2,12 +2,13 @@ import { Class } from '@nestjs-query/core';
 import omit from 'lodash.omit';
 import { ArgsType, ID } from 'type-graphql';
 import { Resolver, Args } from '@nestjs/graphql';
+import { QueryArgsTypeOpts } from '../types/query/query-args.type';
 import { BaseServiceResolver, ResolverClass, ResolverOpts, ServiceResolver } from './resolver.interface';
 import { ConnectionType, QueryArgsType, StaticConnectionType, StaticQueryType } from '../types';
 import { ResolverQuery } from '../decorators';
 import { DTONamesOpts, getDTONames, transformAndValidate } from './helpers';
 
-export interface ReadResolverOpts<DTO> extends DTONamesOpts, ResolverOpts {
+export interface ReadResolverOpts<DTO> extends DTONamesOpts, ResolverOpts, QueryArgsTypeOpts<DTO> {
   QueryArgs?: StaticQueryType<DTO>;
   Connection?: StaticConnectionType<DTO>;
 }
@@ -26,7 +27,7 @@ export const Readable = <DTO>(DTOClass: Class<DTO>, opts: ReadResolverOpts<DTO>)
 >(
   BaseClass: B,
 ): Class<ReadResolver<DTO>> & B => {
-  const { QueryArgs = QueryArgsType(DTOClass), Connection = ConnectionType(DTOClass) } = opts;
+  const { QueryArgs = QueryArgsType(DTOClass, opts), Connection = ConnectionType(DTOClass) } = opts;
   const { baseNameLower, pluralBaseNameLower } = getDTONames(opts, DTOClass);
 
   const commonResolverOpts = omit(opts, 'dtoName', 'one', 'many', 'QueryArgs', 'Connection');

--- a/packages/query-graphql/src/types/query/paging.type.ts
+++ b/packages/query-graphql/src/types/query/paging.type.ts
@@ -1,6 +1,6 @@
 import { Class, Paging } from '@nestjs-query/core';
-import { Min, Validate } from 'class-validator';
-import { ArgsType, Field, InputType, Int } from 'type-graphql';
+import { Min, Validate, IsPositive } from 'class-validator';
+import { Field, InputType, Int } from 'type-graphql';
 import { cursorToOffset } from 'graphql-relay';
 import { ConnectionCursorType, ConnectionCursorScalar } from '../cursor.scalar';
 import { CannotUseWith, CannotUseWithout, IsUndefined } from '../validators';
@@ -19,7 +19,7 @@ export const CursorPagingType = (): Class<CursorPagingType> => {
   if (graphQLCursorPaging) {
     return graphQLCursorPaging;
   }
-  @ArgsType()
+  // based on https://github.com/MichalLytek/type-graphql/issues/142#issuecomment-433120114
   @InputType('CursorPaging')
   class GraphQLCursorPagingImpl implements CursorPagingType {
     @Field(() => ConnectionCursorScalar, {
@@ -42,6 +42,7 @@ export const CursorPagingType = (): Class<CursorPagingType> => {
 
     @Field(() => Int, { nullable: true, description: 'Paginate first' })
     @IsUndefined()
+    @IsPositive()
     @Min(1)
     @Validate(CannotUseWith, ['before', 'last'])
     first?: number;
@@ -54,6 +55,7 @@ export const CursorPagingType = (): Class<CursorPagingType> => {
     @Validate(CannotUseWithout, ['before'])
     @Validate(CannotUseWith, ['after', 'first'])
     @Min(1)
+    @IsPositive()
     last?: number;
 
     get limit(): number | undefined {

--- a/packages/query-graphql/src/types/validators/property-max.validator.ts
+++ b/packages/query-graphql/src/types/validators/property-max.validator.ts
@@ -1,0 +1,19 @@
+import { ValidatorConstraint, ValidatorConstraintInterface, ValidationArguments } from 'class-validator';
+
+/** @internal */
+@ValidatorConstraint({ async: false })
+export class PropertyMax<T> implements ValidatorConstraintInterface {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  validate(value: any, args: ValidationArguments): boolean {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const object = args.object as any;
+    const field = args.constraints[0] as string;
+    const maxVal = args.constraints[1] as number;
+    const prop = object[args.property] ?? {};
+    return prop[field] !== undefined ? prop[field] <= maxVal : true;
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    return `Field ${args.property}.${args.constraints[0]} max allowed value is \`${args.constraints[1]}\`.`;
+  }
+}


### PR DESCRIPTION
* Add ability to specify query defaults.
   * `defaultResultSize` -  the default number of results to return from a query
   * `maxResultsSize` -  the maximum number of results to return from a query
   * `defaultSort` -  The default sort to apply to queries
   * `defaultFilter` -  The default filter to apply to queries