### PR TITLE
fix: add missing async

### DIFF
--- a/packages/query-typeorm/src/services/typeorm-query.service.ts
+++ b/packages/query-typeorm/src/services/typeorm-query.service.ts
@@ -112,7 +112,7 @@ export class TypeOrmQueryService<Entity> extends RelationQueryService<Entity> im
    * ```
    * @param records - The entities to create.
    */
-  createMany<C extends DeepPartial<Entity>>(records: C[]): Promise<Entity[]> {
+  async createMany<C extends DeepPartial<Entity>>(records: C[]): Promise<Entity[]> {
     return this.repo.save(records);
   }
 


### PR DESCRIPTION
Found a missing `async` keyword on a method. Signature, docs and all other methods in this class imply, that this method should actually be `async` and that you accidentally forgot it ;)