### PR TITLE
fix(docs): remove unused imports in example page

### DIFF
--- a/documentation/docs/introduction/example.mdx
+++ b/documentation/docs/introduction/example.mdx
@@ -152,10 +152,9 @@ Once the resolver is generated paste the following into `src/todo-item/todo-item
 import { QueryService } from '@nestjs-query/core';
 import { CRUDResolver } from '@nestjs-query/query-graphql';
 import { InjectTypeOrmQueryService } from '@nestjs-query/query-typeorm';
-import { Resolver, Query, Args } from '@nestjs/graphql';
+import { Resolver } from '@nestjs/graphql';
 import { TodoItemDTO } from './todo-item.dto';
 import { TodoItemEntity } from './todo-item.entity';
-import { TodoItemService } from './todo-item.service';
 
 @Resolver()
 export class TodoItemResolver extends CRUDResolver(TodoItemDTO) {


### PR DESCRIPTION
When following the steps in the tutorial you'll be presented with this error:

```
src/todo-item/todo-item.resolver.ts:7:33 - error TS2307: Cannot find module './todo-item.service'.

7 import { TodoItemService } from './todo-item.service';
                                  ~~~~~~~~~~~~~~~~~~~~~
```

This patch removes the unused import.