### PR TITLE
docs(resolvers): Add class type to custom CRUDResolver

### DIFF
--- a/documentation/docs/graphql/resolvers.mdx
+++ b/documentation/docs/graphql/resolvers.mdx
@@ -83,7 +83,7 @@ import { Resolver, Query, Args } from '@nestjs/graphql';
 import { TodoItemDTO } from './dto/todo-item.dto';
 import { TodoItemEntity } from './todo-item.entity';
 
-@Resolver()
+@Resolver(() => TodoItemDTO)
 export class TodoItemResolver extends CRUDResolver(TodoItemDTO) {
   constructor(
     @InjectQueryService(TodoItemEntity) readonly service: QueryService<TodoItemEntity>


### PR DESCRIPTION
After I transformed an auto-generated resolvers into custom CRUDResolvers with the same options, a few things stopped working.

After some debugging I found the root cause was using @Resolver without specifying the class type, like the docs are showing.

Auto-generated resolvers specify the class type here: https://github.com/doug-martin/nestjs-query/blob/master/packages/query-graphql/src/providers.ts#L112