### PR TITLE
fix(graphql, #505): Less restrictive readResolverOpts for auto crud

### DIFF
--- a/packages/query-graphql/__tests__/module.spec.ts
+++ b/packages/query-graphql/__tests__/module.spec.ts
@@ -24,4 +24,21 @@ describe('NestjsQueryGraphQLModule', () => {
     expect(graphqlModule.providers).toHaveLength(3);
     expect(graphqlModule.exports).toHaveLength(4);
   });
+
+  it('should allow a defaultFilter for read options', () => {
+    const graphqlModule = NestjsQueryGraphQLModule.forFeature({
+      imports: [],
+      resolvers: [
+        {
+          DTOClass: TestDTO,
+          EntityClass: TestDTO,
+          read: { defaultFilter: { name: { eq: 'foo' } } },
+        },
+      ],
+    });
+    expect(graphqlModule.imports).toHaveLength(1);
+    expect(graphqlModule.module).toBe(NestjsQueryGraphQLModule);
+    expect(graphqlModule.providers).toHaveLength(3);
+    expect(graphqlModule.exports).toHaveLength(4);
+  });
 });

--- a/packages/query-graphql/src/module.ts
+++ b/packages/query-graphql/src/module.ts
@@ -12,7 +12,7 @@ export interface NestjsQueryGraphqlModuleOpts {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   assemblers?: Class<Assembler<any, any>>[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  resolvers: AutoResolverOpts<any, any, unknown, unknown, ReadResolverOpts<unknown>, PagingStrategies>[];
+  resolvers: AutoResolverOpts<any, any, unknown, unknown, ReadResolverOpts<any>, PagingStrategies>[];
   pubSub?: Provider<GraphQLPubSub>;
 }
 


### PR DESCRIPTION
* Fix for #505 