### PR TITLE
fix(typeorm, #954): Filtering on relations with pagination

### DIFF
--- a/documentation/docs/concepts/queries.mdx
+++ b/documentation/docs/concepts/queries.mdx
@@ -6,13 +6,13 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 The core of `nestjs-query` is the `Query`, it is used by `@nestjs-query/query-graphql`, `@nestjs-query/query-typeorm`
- `@nestjs-query/query-sequelize` and `@nestjs-query/query-mongoose`.
+`@nestjs-query/query-sequelize` and `@nestjs-query/query-mongoose`.
 
 The query interface contains three optional fields.
 
-* `filter`
-* `paging`
-* `sorting`
+- `filter`
+- `paging`
+- `sorting`
 
 All examples will be based on the following class.
 
@@ -43,7 +43,7 @@ import { Query } from '@nestjs-query/core';
 
 const q: Query<MyClass> = {
   filter: {
-    title: {eq: 'Foo Bar'},
+    title: { eq: 'Foo Bar' },
   },
 };
 ```
@@ -58,9 +58,9 @@ import { Query } from '@nestjs-query/core';
 const q: Query<MyClass> = {
   filter: {
     // title = 'Foo Bar' AND completed IS TRUE and age > 10
-    title: {eq: 'Foo Bar'},
+    title: { eq: 'Foo Bar' },
     completed: { is: true },
-    age: {gt: 10},
+    age: { gt: 10 },
   },
 };
 ```
@@ -75,7 +75,7 @@ import { Query } from '@nestjs-query/core';
 const q: Query<MyClass> = {
   filter: {
     // title = 'Foo Bar' OR field LIKE '%foo%'
-    title: {eq: 'Foo Bar', like: '%foo%'},
+    title: { eq: 'Foo Bar', like: '%foo%' },
   },
 };
 ```
@@ -90,10 +90,7 @@ In this example we `AND` two filters for the same property together: `age >= 10 
 ```ts
 const q: Query<MyClass> = {
   filter: {
-    and: [
-      { age: { gte: 10 } },
-      { age: { lte: 20 } },
-    ],
+    and: [{ age: { gte: 10 } }, { age: { lte: 20 } }],
   },
 };
 ```
@@ -103,10 +100,7 @@ In this example a simple `OR` condition is created: `age >= 10 OR title NOT LIKE
 ```ts
 const q: Query<MyClass> = {
   filter: {
-    or: [
-      { age: { gte: 10 } },
-      { title: { notLike: '%bar' } },
-    ],
+    or: [{ age: { gte: 10 } }, { title: { notLike: '%bar' } }],
   },
 };
 ```
@@ -119,10 +113,7 @@ const q: Query<MyClass> = {
     and: [
       { age: { gte: 10 } },
       {
-        or: [
-          { title: { like: '%bar' } },
-          { title: { eq: 'foobar' } },
-        ],
+        or: [{ title: { like: '%bar' } }, { title: { eq: 'foobar' } }],
       },
     ],
   },
@@ -179,6 +170,11 @@ const q: Query<MyClass> = {
 </TabItem>
 </Tabs>
 
+:::note
+When using filters on relations in combination with paging, performance can be degraded on large result sets.
+For more info see this [issue](https://github.com/doug-martin/nestjs-query/issues/954)
+:::
+
 ---
 
 ## Sorting
@@ -186,9 +182,10 @@ const q: Query<MyClass> = {
 The `sorting` field allows to specify the sort order for your query.
 
 The `sorting` field is an array of object containing:
- * `field` - the field to sort on
- * `direction` - `ASC` or `DESC`
- * `nulls?` - Optional nulls sort, `NULLS_FIRST` or `NULLS_LAST`
+
+- `field` - the field to sort on
+- `direction` - `ASC` or `DESC`
+- `nulls?` - Optional nulls sort, `NULLS_FIRST` or `NULLS_LAST`
 
 <Tabs
   defaultValue="single"
@@ -203,7 +200,7 @@ The `sorting` field is an array of object containing:
 // import { SortDirection } from '@nestjs-query/core';
 
 const q: Query<MyClass> = {
-    sorting: [{field: 'title', direction: SortDirection.DESC}],
+  sorting: [{ field: 'title', direction: SortDirection.DESC }],
 };
 ```
 
@@ -214,12 +211,11 @@ const q: Query<MyClass> = {
 // import { SortDirection } from '@nestjs-query/core';
 
 const q: Query<MyClass> = {
-    sorting: [
-        {field: 'title', direction: SortDirection.DESC},
-        {field: 'age', direction: SortDirection.ASC},
-    ],
+  sorting: [
+    { field: 'title', direction: SortDirection.DESC },
+    { field: 'age', direction: SortDirection.ASC },
+  ],
 };
-
 ```
 
 </TabItem>
@@ -237,85 +233,143 @@ The following examples show an approximation of the SQL that will be generated. 
 
 All types support the following comparisons.
 
-* `is` - Check is a field is `null`, `true` or `false`.
-    ```ts
-    // title IS NULL
-    { title: { is: null } }
-    // completed IS TRUE
-    { completed: { is: true } }
-    // completed IS false
-    { completed: { is: false } }
-    ```
-* `isNot` - Check is a field is not `null`, `true` or `false`.
-    ```ts
-    // title IS NOT NULL
-    { title: { isNot: null } }
-    // completed IS NOT TRUE
-    { completed: { isNot: true } }
-    // completed IS NOT false
-    { completed: { isNot: false } }
-    ```
-* `neq` - field is not equal to a value.
-    ```ts
-    // title != 'foo'
-    { title: { neq: 'foo' } }
-    ```
-* `gt` - field is greater than a value.
-    ```ts
-    // title > 'foo'
-    { title: { gt: 'foo' } }
-    ```
-* `gte` - field is greater than or equal to a value.
-    ```ts
-    // title >= 'foo'
-    { title: { gte: 'foo' } }
-    ```
-* `lt` - field is less than a value.
-    ```ts
-    // title < 'foo'
-    { title: { lt: 'foo' } }
-    ```
-* `lte` - field is less than or equal to a value.
-    ```ts
-    // title <= 'foo'
-    { title: { lte: 'foo' } }
-    ```
-* `in` - field is in a list of values.
-    ```ts
-    // title IN ('foo', 'bar', 'baz')
-    { title: { in: ['foo', 'bar', 'baz'] } }
-    ```
-* `notIn` - field is not in a list of values.
-    ```ts
-    // title NOT IN ('foo', 'bar', 'baz')
-    { title: { notIn: ['foo', 'bar', 'baz'] } }
-    ```
+- `is` - Check is a field is `null`, `true` or `false`.
+  ```ts
+  // title IS NULL
+  {
+    title: {
+      is: null;
+    }
+  }
+  // completed IS TRUE
+  {
+    completed: {
+      is: true;
+    }
+  }
+  // completed IS false
+  {
+    completed: {
+      is: false;
+    }
+  }
+  ```
+- `isNot` - Check is a field is not `null`, `true` or `false`.
+  ```ts
+  // title IS NOT NULL
+  {
+    title: {
+      isNot: null;
+    }
+  }
+  // completed IS NOT TRUE
+  {
+    completed: {
+      isNot: true;
+    }
+  }
+  // completed IS NOT false
+  {
+    completed: {
+      isNot: false;
+    }
+  }
+  ```
+- `neq` - field is not equal to a value.
+  ```ts
+  // title != 'foo'
+  {
+    title: {
+      neq: 'foo';
+    }
+  }
+  ```
+- `gt` - field is greater than a value.
+  ```ts
+  // title > 'foo'
+  {
+    title: {
+      gt: 'foo';
+    }
+  }
+  ```
+- `gte` - field is greater than or equal to a value.
+  ```ts
+  // title >= 'foo'
+  {
+    title: {
+      gte: 'foo';
+    }
+  }
+  ```
+- `lt` - field is less than a value.
+  ```ts
+  // title < 'foo'
+  {
+    title: {
+      lt: 'foo';
+    }
+  }
+  ```
+- `lte` - field is less than or equal to a value.
+  ```ts
+  // title <= 'foo'
+  {
+    title: {
+      lte: 'foo';
+    }
+  }
+  ```
+- `in` - field is in a list of values.
+  ```ts
+  // title IN ('foo', 'bar', 'baz')
+  { title: { in: ['foo', 'bar', 'baz'] } }
+  ```
+- `notIn` - field is not in a list of values.
+  ```ts
+  // title NOT IN ('foo', 'bar', 'baz')
+  {
+    title: {
+      notIn: ['foo', 'bar', 'baz'];
+    }
+  }
+  ```
 
 ### String Comparisons
 
-* `like` - field is like a value (case sensitive).
-    ```ts
-    // title LIKE 'Foo%'
-    { title: { like: 'Foo%' } }
-    ```
-* `notLike` - field is not like a value  (case sensitive).
-    ```ts
-    // title NOT LIKE 'Foo%'
-    { title: { notLike: 'Foo%' } }
-    ```
-* `iLike` - field is like a value (case insensitive).
-    ```ts
-    // title ILIKE 'Foo%'
-    { title: { iLike: 'Foo%' } }
-    ```
-* `notILike` - field is not like a value  (case insensitive).
-    ```ts
-    // title NOT ILIKE 'Foo%'
-    { title: { notILike: 'Foo%' } }
-    ```
-
-
-
-
-
-
+- `like` - field is like a value (case sensitive).
+  ```ts
+  // title LIKE 'Foo%'
+  {
+    title: {
+      like: 'Foo%';
+    }
+  }
+  ```
+- `notLike` - field is not like a value (case sensitive).
+  ```ts
+  // title NOT LIKE 'Foo%'
+  {
+    title: {
+      notLike: 'Foo%';
+    }
+  }
+  ```
+- `iLike` - field is like a value (case insensitive).
+  ```ts
+  // title ILIKE 'Foo%'
+  {
+    title: {
+      iLike: 'Foo%';
+    }
+  }
+  ```
+- `notILike` - field is not like a value (case insensitive).
+  ```ts
+  // title NOT ILIKE 'Foo%'
+  {
+    title: {
+      notILike: 'Foo%';
+    }
+  }
+  ```

--- a/examples/basic/e2e/todo-item.resolver.spec.ts
+++ b/examples/basic/e2e/todo-item.resolver.spec.ts
@@ -206,11 +206,11 @@ describe('TodoItemResolver (basic - e2e)', () => {
           operationName: null,
           variables: {},
           query: `{
-            todoItems(filter: { subTasks: { title: { eq: "Create Nest App - Sub Task 1" } } }) {
+            todoItems(filter: { subTasks: { title: { eq: "Create Nest App - Sub Task 1" } } }, sorting: [{field: id, direction: ASC}]) {
               ${pageInfoField}
               ${edgeNodes(`
                 ${todoItemFields}
-                subTasks {
+                subTasks (sorting: [{field: id, direction: ASC}]) {
                   ${pageInfoField}
                   ${edgeNodes(subTaskFields)}
                 }
@@ -293,30 +293,124 @@ describe('TodoItemResolver (basic - e2e)', () => {
                  { id: { eq: 2 } }, 
                  { subTasks: { title: { like: "Create Nest App%" } } } 
                ]
-             }
+             },
+             sorting: [{field: id, direction: ASC}]
           ) {
-              edges {
-                node {
-                  id
-                  title
-                }
+            ${pageInfoField}
+            ${edgeNodes(`
+              ${todoItemFields}
+              subTasks (sorting: [{field: id, direction: ASC}]) {
+                ${pageInfoField}
+                ${edgeNodes(subTaskFields)}
               }
+            `)}
             }
           }`,
         })
         .expect(200)
         .then(({ body }) => {
-          const { edges }: CursorConnectionType<TodoItemDTO> = body.data.todoItems;
+          const { edges, pageInfo }: CursorConnectionType<TodoItemDTO> = body.data.todoItems;
           expect(edges).toHaveLength(2);
+
+          expect(pageInfo).toEqual({
+            endCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+          });
 
           expect(edges.map((e) => e.node)).toEqual([
             {
               id: '1',
               title: 'Create Nest App',
+              completed: true,
+              description: null,
+              subTasks: {
+                pageInfo: {
+                  endCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+                },
+                edges: [
+                  {
+                    node: {
+                      id: '1',
+                      completed: true,
+                      title: `Create Nest App - Sub Task 1`,
+                      description: null,
+                      todoItemId: '1',
+                    },
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+                  },
+                  {
+                    node: {
+                      id: '2',
+                      completed: false,
+                      title: `Create Nest App - Sub Task 2`,
+                      description: null,
+                      todoItemId: '1',
+                    },
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjE=',
+                  },
+                  {
+                    node: {
+                      id: '3',
+                      completed: false,
+                      title: `Create Nest App - Sub Task 3`,
+                      description: null,
+                      todoItemId: '1',
+                    },
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjI=',
+                  },
+                ],
+              },
             },
             {
               id: '2',
               title: 'Create Entity',
+              completed: false,
+              description: null,
+              subTasks: {
+                pageInfo: {
+                  endCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
+                  hasNextPage: false,
+                  hasPreviousPage: false,
+                  startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+                },
+                edges: [
+                  {
+                    node: {
+                      id: '4',
+                      completed: true,
+                      title: `Create Entity - Sub Task 1`,
+                      description: null,
+                      todoItemId: '2',
+                    },
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+                  },
+                  {
+                    node: {
+                      id: '5',
+                      completed: false,
+                      title: `Create Entity - Sub Task 2`,
+                      description: null,
+                      todoItemId: '2',
+                    },
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjE=',
+                  },
+                  {
+                    node: {
+                      id: '6',
+                      completed: false,
+                      title: `Create Entity - Sub Task 3`,
+                      description: null,
+                      todoItemId: '2',
+                    },
+                    cursor: 'YXJyYXljb25uZWN0aW9uOjI=',
+                  },
+                ],
+              },
             },
           ]);
         }));

--- a/examples/basic/src/todo-item/dto/todo-item.dto.ts
+++ b/examples/basic/src/todo-item/dto/todo-item.dto.ts
@@ -1,11 +1,11 @@
-import { FilterableField, CursorConnection } from '@nestjs-query/query-graphql';
+import { FilterableCursorConnection, FilterableField } from '@nestjs-query/query-graphql';
 import { ObjectType, ID, GraphQLISODateTime } from '@nestjs/graphql';
 import { SubTaskDTO } from '../../sub-task/dto/sub-task.dto';
 import { TagDTO } from '../../tag/dto/tag.dto';
 
 @ObjectType('TodoItem')
-@CursorConnection('subTasks', () => SubTaskDTO, { disableRemove: true })
-@CursorConnection('tags', () => TagDTO)
+@FilterableCursorConnection('subTasks', () => SubTaskDTO, { disableRemove: true })
+@FilterableCursorConnection('tags', () => TagDTO)
 export class TodoItemDTO {
   @FilterableField(() => ID)
   id!: number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2533,9 +2533,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.1.tgz",
-          "integrity": "sha512-FYhSdJrU5cZ8BRuzCVV+YixLx3mXYVzowpKGPfI7re9/WvQPjlyIcjG+hd0C4u/L9Dxx46nBkiqZxZZknE6/lA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.2.tgz",
+          "integrity": "sha512-/ml6AUCmtjvvxR9JX9/xyV52759SqbFR74K8i+AzyOzqM3Ns0c0ZpBFdIMiKzh6UYULPsoHblzfj0ES1yrrtGw==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -2567,9 +2567,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.1.tgz",
-          "integrity": "sha512-FYhSdJrU5cZ8BRuzCVV+YixLx3mXYVzowpKGPfI7re9/WvQPjlyIcjG+hd0C4u/L9Dxx46nBkiqZxZZknE6/lA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.2.tgz",
+          "integrity": "sha512-/ml6AUCmtjvvxR9JX9/xyV52759SqbFR74K8i+AzyOzqM3Ns0c0ZpBFdIMiKzh6UYULPsoHblzfj0ES1yrrtGw==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -2607,9 +2607,9 @@
           }
         },
         "@graphql-tools/utils": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.1.tgz",
-          "integrity": "sha512-FYhSdJrU5cZ8BRuzCVV+YixLx3mXYVzowpKGPfI7re9/WvQPjlyIcjG+hd0C4u/L9Dxx46nBkiqZxZZknE6/lA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.2.tgz",
+          "integrity": "sha512-/ml6AUCmtjvvxR9JX9/xyV52759SqbFR74K8i+AzyOzqM3Ns0c0ZpBFdIMiKzh6UYULPsoHblzfj0ES1yrrtGw==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -2634,9 +2634,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.1.tgz",
-          "integrity": "sha512-FYhSdJrU5cZ8BRuzCVV+YixLx3mXYVzowpKGPfI7re9/WvQPjlyIcjG+hd0C4u/L9Dxx46nBkiqZxZZknE6/lA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.2.tgz",
+          "integrity": "sha512-/ml6AUCmtjvvxR9JX9/xyV52759SqbFR74K8i+AzyOzqM3Ns0c0ZpBFdIMiKzh6UYULPsoHblzfj0ES1yrrtGw==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -2662,9 +2662,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.1.tgz",
-          "integrity": "sha512-FYhSdJrU5cZ8BRuzCVV+YixLx3mXYVzowpKGPfI7re9/WvQPjlyIcjG+hd0C4u/L9Dxx46nBkiqZxZZknE6/lA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.2.tgz",
+          "integrity": "sha512-/ml6AUCmtjvvxR9JX9/xyV52759SqbFR74K8i+AzyOzqM3Ns0c0ZpBFdIMiKzh6UYULPsoHblzfj0ES1yrrtGw==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -2696,9 +2696,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.1.tgz",
-          "integrity": "sha512-FYhSdJrU5cZ8BRuzCVV+YixLx3mXYVzowpKGPfI7re9/WvQPjlyIcjG+hd0C4u/L9Dxx46nBkiqZxZZknE6/lA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.2.tgz",
+          "integrity": "sha512-/ml6AUCmtjvvxR9JX9/xyV52759SqbFR74K8i+AzyOzqM3Ns0c0ZpBFdIMiKzh6UYULPsoHblzfj0ES1yrrtGw==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -2837,9 +2837,9 @@
           }
         },
         "@graphql-tools/utils": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.1.tgz",
-          "integrity": "sha512-FYhSdJrU5cZ8BRuzCVV+YixLx3mXYVzowpKGPfI7re9/WvQPjlyIcjG+hd0C4u/L9Dxx46nBkiqZxZZknE6/lA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.2.tgz",
+          "integrity": "sha512-/ml6AUCmtjvvxR9JX9/xyV52759SqbFR74K8i+AzyOzqM3Ns0c0ZpBFdIMiKzh6UYULPsoHblzfj0ES1yrrtGw==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -2889,9 +2889,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.1.tgz",
-          "integrity": "sha512-FYhSdJrU5cZ8BRuzCVV+YixLx3mXYVzowpKGPfI7re9/WvQPjlyIcjG+hd0C4u/L9Dxx46nBkiqZxZZknE6/lA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.2.tgz",
+          "integrity": "sha512-/ml6AUCmtjvvxR9JX9/xyV52759SqbFR74K8i+AzyOzqM3Ns0c0ZpBFdIMiKzh6UYULPsoHblzfj0ES1yrrtGw==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -2927,9 +2927,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.1.tgz",
-          "integrity": "sha512-FYhSdJrU5cZ8BRuzCVV+YixLx3mXYVzowpKGPfI7re9/WvQPjlyIcjG+hd0C4u/L9Dxx46nBkiqZxZZknE6/lA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.2.tgz",
+          "integrity": "sha512-/ml6AUCmtjvvxR9JX9/xyV52759SqbFR74K8i+AzyOzqM3Ns0c0ZpBFdIMiKzh6UYULPsoHblzfj0ES1yrrtGw==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -2989,9 +2989,9 @@
           }
         },
         "@graphql-tools/utils": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.1.tgz",
-          "integrity": "sha512-FYhSdJrU5cZ8BRuzCVV+YixLx3mXYVzowpKGPfI7re9/WvQPjlyIcjG+hd0C4u/L9Dxx46nBkiqZxZZknE6/lA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.2.tgz",
+          "integrity": "sha512-/ml6AUCmtjvvxR9JX9/xyV52759SqbFR74K8i+AzyOzqM3Ns0c0ZpBFdIMiKzh6UYULPsoHblzfj0ES1yrrtGw==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -3014,9 +3014,9 @@
       }
     },
     "@graphql-tools/load-files": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load-files/-/load-files-6.3.0.tgz",
-      "integrity": "sha512-qDEMz3f5CQz8lIvIhzJVK6Fvd6TMMbhuqded4x5I6zWEetR4AUmwneHWnQkwyIRqDDGgy6VlBw7GToucUkvQag==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/load-files/-/load-files-6.3.1.tgz",
+      "integrity": "sha512-y/qGcuKWW3mSPbIHEN5csM9xM0ow479NqtEOPeC1i9wqLml82ubaPS8BzXMhB8DJa5XmrGzIZvrt03CBkQ4aJA==",
       "requires": {
         "globby": "11.0.2",
         "tslib": "~2.1.0",
@@ -3050,9 +3050,9 @@
           }
         },
         "@graphql-tools/utils": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.1.tgz",
-          "integrity": "sha512-FYhSdJrU5cZ8BRuzCVV+YixLx3mXYVzowpKGPfI7re9/WvQPjlyIcjG+hd0C4u/L9Dxx46nBkiqZxZZknE6/lA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.2.tgz",
+          "integrity": "sha512-/ml6AUCmtjvvxR9JX9/xyV52759SqbFR74K8i+AzyOzqM3Ns0c0ZpBFdIMiKzh6UYULPsoHblzfj0ES1yrrtGw==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -3093,9 +3093,9 @@
           }
         },
         "@graphql-tools/utils": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.1.tgz",
-          "integrity": "sha512-FYhSdJrU5cZ8BRuzCVV+YixLx3mXYVzowpKGPfI7re9/WvQPjlyIcjG+hd0C4u/L9Dxx46nBkiqZxZZknE6/lA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.2.tgz",
+          "integrity": "sha512-/ml6AUCmtjvvxR9JX9/xyV52759SqbFR74K8i+AzyOzqM3Ns0c0ZpBFdIMiKzh6UYULPsoHblzfj0ES1yrrtGw==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -3126,9 +3126,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.1.tgz",
-          "integrity": "sha512-FYhSdJrU5cZ8BRuzCVV+YixLx3mXYVzowpKGPfI7re9/WvQPjlyIcjG+hd0C4u/L9Dxx46nBkiqZxZZknE6/lA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.2.tgz",
+          "integrity": "sha512-/ml6AUCmtjvvxR9JX9/xyV52759SqbFR74K8i+AzyOzqM3Ns0c0ZpBFdIMiKzh6UYULPsoHblzfj0ES1yrrtGw==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -3168,9 +3168,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.1.tgz",
-          "integrity": "sha512-FYhSdJrU5cZ8BRuzCVV+YixLx3mXYVzowpKGPfI7re9/WvQPjlyIcjG+hd0C4u/L9Dxx46nBkiqZxZZknE6/lA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.2.tgz",
+          "integrity": "sha512-/ml6AUCmtjvvxR9JX9/xyV52759SqbFR74K8i+AzyOzqM3Ns0c0ZpBFdIMiKzh6UYULPsoHblzfj0ES1yrrtGw==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -3202,9 +3202,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.1.tgz",
-          "integrity": "sha512-FYhSdJrU5cZ8BRuzCVV+YixLx3mXYVzowpKGPfI7re9/WvQPjlyIcjG+hd0C4u/L9Dxx46nBkiqZxZZknE6/lA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.2.tgz",
+          "integrity": "sha512-/ml6AUCmtjvvxR9JX9/xyV52759SqbFR74K8i+AzyOzqM3Ns0c0ZpBFdIMiKzh6UYULPsoHblzfj0ES1yrrtGw==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -3274,9 +3274,9 @@
           }
         },
         "@graphql-tools/utils": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.1.tgz",
-          "integrity": "sha512-FYhSdJrU5cZ8BRuzCVV+YixLx3mXYVzowpKGPfI7re9/WvQPjlyIcjG+hd0C4u/L9Dxx46nBkiqZxZZknE6/lA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.2.tgz",
+          "integrity": "sha512-/ml6AUCmtjvvxR9JX9/xyV52759SqbFR74K8i+AzyOzqM3Ns0c0ZpBFdIMiKzh6UYULPsoHblzfj0ES1yrrtGw==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -3315,9 +3315,9 @@
       },
       "dependencies": {
         "@graphql-tools/utils": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.1.tgz",
-          "integrity": "sha512-FYhSdJrU5cZ8BRuzCVV+YixLx3mXYVzowpKGPfI7re9/WvQPjlyIcjG+hd0C4u/L9Dxx46nBkiqZxZZknE6/lA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.2.tgz",
+          "integrity": "sha512-/ml6AUCmtjvvxR9JX9/xyV52759SqbFR74K8i+AzyOzqM3Ns0c0ZpBFdIMiKzh6UYULPsoHblzfj0ES1yrrtGw==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -3430,9 +3430,9 @@
           }
         },
         "@graphql-tools/utils": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.1.tgz",
-          "integrity": "sha512-FYhSdJrU5cZ8BRuzCVV+YixLx3mXYVzowpKGPfI7re9/WvQPjlyIcjG+hd0C4u/L9Dxx46nBkiqZxZZknE6/lA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.2.tgz",
+          "integrity": "sha512-/ml6AUCmtjvvxR9JX9/xyV52759SqbFR74K8i+AzyOzqM3Ns0c0ZpBFdIMiKzh6UYULPsoHblzfj0ES1yrrtGw==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -6605,8 +6605,7 @@
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "optional": true
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
       }
     },
@@ -8231,8 +8230,7 @@
         "indent-string": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-          "optional": true
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
         }
       }
     },
@@ -9748,9 +9746,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001197",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001197.tgz",
-      "integrity": "sha512-8aE+sqBqtXz4G8g35Eg/XEaFr2N7rd/VQ6eABGBmNtcB8cN6qNJhMi6oSFy4UWWZgqgL3filHT8Nha4meu3tsw=="
+      "version": "1.0.30001198",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001198.tgz",
+      "integrity": "sha512-r5GGgESqOPZzwvdLVER374FpQu2WluCF1Z2DSiFJ89KSmGjT0LVKjgv4NcAqHmGWF9ihNpqRI9KXO9Ex4sKsgA=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -9905,8 +9903,7 @@
     "clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "optional": true
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "cli-cursor": {
       "version": "3.1.0",
@@ -12084,9 +12081,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.683",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.683.tgz",
-      "integrity": "sha512-8mFfiAesXdEdE0DhkMKO7W9U6VU/9T3VTWwZ+4g84/YMP4kgwgFtQgUxuu7FUMcvSeKSNhFQNU+WZ68BQTLT5A=="
+      "version": "1.3.684",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.684.tgz",
+      "integrity": "sha512-GV/vz2EmmtRSvfGSQ5A0Lucic//IRSDijgL15IgzbBEEnp4rfbxeUSZSlBfmsj7BQvE4sBdgfsvPzLCnp6L21w=="
     },
     "emittery": {
       "version": "0.7.2",
@@ -12108,6 +12105,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "optional": true,
       "requires": {
         "iconv-lite": "^0.6.2"
       },
@@ -12116,6 +12114,7 @@
           "version": "0.6.2",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
           "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
@@ -14799,9 +14798,9 @@
           }
         },
         "@graphql-tools/utils": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.1.tgz",
-          "integrity": "sha512-FYhSdJrU5cZ8BRuzCVV+YixLx3mXYVzowpKGPfI7re9/WvQPjlyIcjG+hd0C4u/L9Dxx46nBkiqZxZZknE6/lA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.5.2.tgz",
+          "integrity": "sha512-/ml6AUCmtjvvxR9JX9/xyV52759SqbFR74K8i+AzyOzqM3Ns0c0ZpBFdIMiKzh6UYULPsoHblzfj0ES1yrrtGw==",
           "requires": {
             "@ardatan/aggregate-error": "0.0.6",
             "camel-case": "4.1.2",
@@ -19910,7 +19909,6 @@
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
           "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-          "optional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -19918,8 +19916,7 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "optional": true
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -19938,7 +19935,6 @@
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
           "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-          "optional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -19947,7 +19943,6 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
           "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-          "optional": true,
           "requires": {
             "minipass": "^3.0.0",
             "yallist": "^4.0.0"
@@ -19956,8 +19951,7 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "optional": true
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -19973,7 +19967,6 @@
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
           "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-          "optional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -19981,8 +19974,7 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "optional": true
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -20019,7 +20011,6 @@
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
           "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-          "optional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -20027,8 +20018,7 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "optional": true
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -20036,7 +20026,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
       "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-      "optional": true,
       "requires": {
         "minipass": "^3.0.0"
       },
@@ -20045,7 +20034,6 @@
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
           "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-          "optional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -20053,8 +20041,7 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "optional": true
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -21302,9 +21289,9 @@
       }
     },
     "optimism": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.14.0.tgz",
-      "integrity": "sha512-ygbNt8n4DOCVpkwiLF+IrKKeNHOjtr9aXLWGP9HNJGoblSGsnVbJLstcH6/nE9Xy5ZQtlkSioFQNnthmENW6FQ==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.14.1.tgz",
+      "integrity": "sha512-7+1lSN+LJEtaj3uBLLFk8uFCFKy3txLvcvln5Dh1szXjF9yghEMeWclmnk0qdtYZ+lcMNyu48RmQQRw+LRYKSQ==",
       "requires": {
         "@wry/context": "^0.5.2",
         "@wry/trie": "^0.2.1"

--- a/packages/query-typeorm/src/query/filter-query.builder.ts
+++ b/packages/query-typeorm/src/query/filter-query.builder.ts
@@ -28,6 +28,8 @@ interface Sortable<Entity> extends QueryBuilder<Entity> {
 interface Pageable<Entity> extends QueryBuilder<Entity> {
   limit(limit?: number): this;
   offset(offset?: number): this;
+  skip(skip?: number): this;
+  take(take?: number): this;
 }
 
 /**
@@ -49,20 +51,22 @@ export class FilterQueryBuilder<Entity> {
    */
   select(query: Query<Entity>): SelectQueryBuilder<Entity> {
     let qb = this.createQueryBuilder();
-    qb = this.applyRelationJoins(qb, query.filter);
+    let hasRelations = false;
+    [qb, hasRelations] = this.applyRelationJoins(qb, query.filter);
     qb = this.applyFilter(qb, query.filter, qb.alias);
     qb = this.applySorting(qb, query.sorting, qb.alias);
-    qb = this.applyPaging(qb, query.paging);
+    qb = this.applyPaging(qb, query.paging, hasRelations);
     return qb;
   }
 
   selectById(id: string | number | (string | number)[], query: Query<Entity>): SelectQueryBuilder<Entity> {
     let qb = this.createQueryBuilder();
-    qb = this.applyRelationJoins(qb, query.filter);
+    let hasRelations = false;
+    [qb, hasRelations] = this.applyRelationJoins(qb, query.filter);
     qb = qb.andWhereInIds(id);
     qb = this.applyFilter(qb, query.filter, qb.alias);
     qb = this.applySorting(qb, query.sorting, qb.alias);
-    qb = this.applyPaging(qb, query.paging);
+    qb = this.applyPaging(qb, query.paging, hasRelations);
     return qb;
   }
 
@@ -109,10 +113,15 @@ export class FilterQueryBuilder<Entity> {
    * @param qb - the `typeorm` QueryBuilder
    * @param paging - the Paging options.
    */
-  applyPaging<P extends Pageable<Entity>>(qb: P, paging?: Paging): P {
+  applyPaging<P extends Pageable<Entity>>(qb: P, paging?: Paging, useSkipTake?: boolean): P {
     if (!paging) {
       return qb;
     }
+
+    if (useSkipTake) {
+      return qb.take(paging.limit).skip(paging.offset);
+    }
+
     return qb.limit(paging.limit).offset(paging.offset);
   }
 
@@ -165,12 +174,25 @@ export class FilterQueryBuilder<Entity> {
     return this.repo.createQueryBuilder();
   }
 
-  private applyRelationJoins(qb: SelectQueryBuilder<Entity>, filter?: Filter<Entity>): SelectQueryBuilder<Entity> {
+  /**
+   * Gets relations referenced in the filter and adds joins for them to the query builder
+   * @param qb - the `typeorm` QueryBuilder.
+   * @param filter - the filter.
+   *
+   * @returns the query builder for chaining and a boolean indicating if relations have been added to the filter
+   */
+  private applyRelationJoins(
+    qb: SelectQueryBuilder<Entity>,
+    filter?: Filter<Entity>,
+  ): [SelectQueryBuilder<Entity>, boolean] {
     if (!filter) {
-      return qb;
+      return [qb, false];
     }
     const referencedRelations = this.getReferencedRelations(filter);
-    return referencedRelations.reduce((rqb, relation) => rqb.leftJoin(`${rqb.alias}.${relation}`, relation), qb);
+    return [
+      referencedRelations.reduce((rqb, relation) => rqb.leftJoin(`${rqb.alias}.${relation}`, relation), qb),
+      referencedRelations.length > 0,
+    ];
   }
 
   private getReferencedRelations(filter: Filter<Entity>): string[] {

--- a/packages/query-typeorm/src/query/filter-query.builder.ts
+++ b/packages/query-typeorm/src/query/filter-query.builder.ts
@@ -112,6 +112,7 @@ export class FilterQueryBuilder<Entity> {
    * Applies paging to a Pageable `typeorm` query builder
    * @param qb - the `typeorm` QueryBuilder
    * @param paging - the Paging options.
+   * @param useSkipTake - if skip/take should be used instead of limit/offset.
    */
   applyPaging<P extends Pageable<Entity>>(qb: P, paging?: Paging, useSkipTake?: boolean): P {
     if (!paging) {


### PR DESCRIPTION
This pull request fixes the issues described in #954.

**Contents**
- 2 new e2e test cases in the "basic" example:
  - Test that filters on a relation without paging
  - Test that filters on a relation with additional paging (the breaking example)
- Fixed the filter-query-builder to use skip/take whenever joins are present. Otherwise it should stick with limit/offset for performance reasons
- Added a note in the docs (under /concepts/queries#paging) stating that there might be performance issues when filtering and paging relations with a large result set and a link to the issue for further reading.

**Tests**
All relevant tests passed on my machine.

***Side Note***
Just checked on current master (beb96c3) those unrelated tests fail on my machine:
- TypeOrmQueryService › #aggregate › call select with the aggregate columns and return the result
- TypeOrmQueryService › #aggregate › call select with the aggregate columns and return the result with a filter
- SequelizeQueryService › #aggregate › call select with the aggregate columns and return the result
- SequelizeQueryService › #aggregate › call select with the aggregate columns and return the result with a filter

they all have the same reason:
```
-     "dateType": StringMatching /2020-02-03/,
+     "dateType": "2020-02-02 23:00:00.000 +00:00",
```