### PR TITLE
feat(): Add groupBy support for aggregate queries

### DIFF
--- a/documentation/docs/concepts/services.md
+++ b/documentation/docs/concepts/services.md
@@ -85,7 +85,7 @@ Delete a single record.
 `Promise<DTO>`
 
 ### `aggregate`
-Performs an aggregate query, supported aggregate functions are `count`, `sum`, `avg`, `min`, and `max`
+Performs an aggregate query, supported aggregate functions are `groupBy`, `count`, `sum`, `avg`, `min`, and `max`
 #### Arguments
 * `filter: Filter<DTO>` - Additional filter to apply
 * `aggregate: AggregateQuery<DTO>` - The aggregate query
@@ -103,18 +103,20 @@ Example `AggregateQuery`
 ```
 
 #### Returns
-An aggregate response.
+An array of aggregate responses.
 
 Example `AggregateResponse`
 
 ```ts
-{
-  count: { id: 5 },
-  sum: { id: 10 },
-  avg: { id: 2.5 },
-  min: {id: 1, title: 'A Title'},
-  max: {id: 4, title: 'Z Title'}
-}
+[
+  {
+    count: { id: 5 },
+    sum: { id: 10 },
+    avg: { id: 2.5 },
+    min: {id: 1, title: 'A Title'},
+    max: {id: 4, title: 'Z Title'}
+  }
+]
 ```
 
 ### `count`

--- a/documentation/docs/graphql/aggregations.mdx
+++ b/documentation/docs/graphql/aggregations.mdx
@@ -97,7 +97,7 @@ type Query {
 
     sorting: [TodoItemSort!] = []
   ): TodoItemConnection!
-  todoItemAggregate(filter: TodoItemAggregateFilter): TodoItemAggregateResponse!
+  todoItemAggregate(filter: TodoItemAggregateFilter): [TodoItemAggregateResponse!]!
 }
 
 input TodoItemAggregateFilter {
@@ -113,6 +113,7 @@ input TodoItemAggregateFilter {
 }
 
 type TodoItemAggregateResponse {
+  groupBy: TodoItemAggregateGroupBy
   count: TodoItemCountAggregate
   sum: TodoItemSumAggregate
   avg: TodoItemAvgAggregate
@@ -123,6 +124,18 @@ type TodoItemAggregateResponse {
 type TodoItemAvgAggregate {
   id: Float
   priority: Float
+}
+
+type TodoItemAggregateGroupBy {
+  id: ID
+  title: String
+  description: String
+  completed: Boolean
+  created: DateTime
+  updated: DateTime
+  priority: Float
+  createdBy: String
+  updatedBy: String
 }
 
 type TodoItemCountAggregate {
@@ -206,27 +219,133 @@ type TodoItemSumAggregate {
 ```json
 {
   "data": {
-    "todoItemAggregate": {
-      "count": {
-        "id": 5
-      },
-      "sum": {
-        "id": 15
-      },
-      "avg": {
-        "id": 3
-      },
-      "min": {
-        "id": "1",
-        "title": "Add Todo Item Resolver",
-        "created": "2020-07-13T01:12:29.773Z"
-      },
-      "max": {
-        "id": "5",
-        "title": "How to create item With Sub Tasks",
-        "created": "2020-07-15T07:12:29.773Z"
+    "todoItemAggregate": [
+      {
+        "count": {
+          "id": 5
+        },
+        "sum": {
+          "id": 15
+        },
+        "avg": {
+          "id": 3
+        },
+        "min": {
+          "id": "1",
+          "title": "Add Todo Item Resolver",
+          "created": "2021-03-29T06:51:26.061Z"
+        },
+        "max": {
+          "id": "5",
+          "title": "How to create item With Sub Tasks",
+          "created": "2021-03-29T06:51:26.061Z"
+        }
       }
+    ]
+  }
+}
+```
+</TabItem>
+</Tabs>
+
+### With GroupBy
+
+To group your aggregate queries you can add a `groupBy` to specify one or more fields to group on.
+
+<Tabs
+  defaultValue="graphql"
+  values={[
+    { label: 'GraphQL', value: 'graphql', },
+    { label: 'Response', value: 'response', },
+  ]
+}>
+<TabItem value="graphql">
+
+```graphql {3-5}
+{
+  todoItemAggregate {
+    groupBy {
+      completed
     }
+    count {
+      id
+    }
+    sum {
+      id
+    }
+    avg {
+      id
+    }
+    min {
+      id
+      title
+      created
+    }
+    max {
+      id
+      title
+      created
+    }
+  }
+}
+```
+
+</TabItem>
+<TabItem value="response">
+
+```json
+{
+  "data": {
+    "todoItemAggregate": [
+      {
+        "groupBy": {
+          "completed": false
+        },
+        "count": {
+          "id": 4
+        },
+        "sum": {
+          "id": 14
+        },
+        "avg": {
+          "id": 3.5
+        },
+        "min": {
+          "id": "2",
+          "title": "Add Todo Item Resolver",
+          "created": "2021-03-29T06:51:26.061Z"
+        },
+        "max": {
+          "id": "5",
+          "title": "How to create item With Sub Tasks",
+          "created": "2021-03-29T06:51:26.061Z"
+        }
+      },
+      {
+        "groupBy": {
+          "completed": true
+        },
+        "count": {
+          "id": 1
+        },
+        "sum": {
+          "id": 1
+        },
+        "avg": {
+          "id": 1
+        },
+        "min": {
+          "id": "1",
+          "title": "Create Nest App",
+          "created": "2021-03-29T06:51:26.061Z"
+        },
+        "max": {
+          "id": "1",
+          "title": "Create Nest App",
+          "created": "2021-03-29T06:51:26.061Z"
+        }
+      }
+    ]
   }
 }
 ```
@@ -273,21 +392,23 @@ You can also provide a filter to only aggregate on a subset of data.
 ```json
 {
   "data": {
-    "todoItemAggregate": {
-      "count": {
-        "id": 4
-      },
-      "min": {
-        "id": "2",
-        "title": "Add Todo Item Resolver",
-        "created": "2020-07-15T07:12:29.773Z"
-      },
-      "max": {
-        "id": "5",
-        "title": "How to create item With Sub Tasks",
-        "created": "2020-07-15T07:12:29.773Z"
+    "todoItemAggregate": [
+      {
+        "count": {
+          "id": 4
+        },
+        "min": {
+          "id": "2",
+          "title": "Add Todo Item Resolver",
+          "created": "2021-03-29T06:51:26.061Z"
+        },
+        "max": {
+          "id": "5",
+          "title": "How to create item With Sub Tasks",
+          "created": "2021-03-29T06:51:26.061Z"
+        }
       }
-    }
+    ]
   }
 }
 ```
@@ -325,13 +446,15 @@ For example assume description is null for all todo items you will get `0` back.
  ```json
 {
   "data": {
-    "todoItemAggregate": {
-      "count": {
-        "id": 4,
-        "title": 4,
-        "description": 0
+    "todoItemAggregate": [
+      {
+        "count": {
+          "id": 4,
+          "title": 4,
+          "description": 0
+        }
       }
-    }
+    ]
   }
 }
 ```
@@ -365,15 +488,28 @@ type TodoItem {
   ): TodoItemSubTasksConnection!
   subTasksAggregate(
     filter: SubTaskAggregateFilter
-  ): TodoItemSubTasksAggregateResponse!
+  ):[ TodoItemSubTasksAggregateResponse!]!
 }
 
 type TodoItemSubTasksAggregateResponse {
+  groupBy: TodoItemSubTasksAggregateGroupBy
   count: TodoItemSubTasksCountAggregate
   sum: TodoItemSubTasksSumAggregate
   avg: TodoItemSubTasksAvgAggregate
   min: TodoItemSubTasksMinAggregate
   max: TodoItemSubTasksMaxAggregate
+}
+
+type TodoItemSubTasksAggregateGroupBy {
+  id: ID
+  title: String
+  description: String
+  completed: Boolean
+  created: DateTime
+  updated: DateTime
+  todoItemId: String
+  createdBy: String
+  updatedBy: String
 }
 
 type TodoItemSubTasksAvgAggregate {
@@ -463,31 +599,138 @@ In this example we'll aggregate on all related `subTasks`.
 {
   "data": {
     "todoItem": {
-      "subTasksAggregate": {
-        "count": {
-          "id": 3
-        },
-        "sum": {
-          "id": 42
-        },
-        "avg": {
-          "id": 14
-        },
-        "min": {
-          "id": "13",
-          "title": "How to create item With Sub Tasks - Sub Task 1"
-        },
-        "max": {
-          "id": "15",
-          "title": "How to create item With Sub Tasks - Sub Task 3"
+      "subTasksAggregate": [
+        {
+          "count": {
+            "id": 3
+          },
+          "sum": {
+            "id": 42
+          },
+          "avg": {
+            "id": 14
+          },
+          "min": {
+            "id": "13",
+            "title": "How to create item With Sub Tasks - Sub Task 1"
+          },
+          "max": {
+            "id": "15",
+            "title": "How to create item With Sub Tasks - Sub Task 3"
+          }
         }
-      }
+      ]
     }
   }
 }
 ```
 </TabItem>
 </Tabs>
+
+### With GroupBy
+
+In this example we'll aggregate on all related `subTasks` and group by `completed`.
+
+<Tabs
+  defaultValue="graphql"
+  values={[
+    { label: 'GraphQL', value: 'graphql', },
+    { label: 'Response', value: 'response', },
+  ]
+}>
+<TabItem value="graphql">
+
+```graphql
+{
+  todoItem(id: 5) {
+    subTasksAggregate {
+      groupBy {
+        completed
+      }
+      count {
+        id
+      }
+      sum {
+        id
+      }
+      avg {
+        id
+      }
+      min {
+        id
+        title
+      }
+      max {
+        id
+        title
+      }
+    }
+  }
+}
+
+```
+
+</TabItem>
+
+<TabItem value="response">
+
+ ```json
+{
+  "data": {
+    "todoItem": {
+      "subTasksAggregate": [
+        {
+          "groupBy": {
+            "completed": false
+          },
+          "count": {
+            "id": 2
+          },
+          "sum": {
+            "id": 29
+          },
+          "avg": {
+            "id": 14.5
+          },
+          "min": {
+            "id": "14",
+            "title": "How to create item With Sub Tasks - Sub Task 2"
+          },
+          "max": {
+            "id": "15",
+            "title": "How to create item With Sub Tasks - Sub Task 3"
+          }
+        },
+        {
+          "groupBy": {
+            "completed": true
+          },
+          "count": {
+            "id": 1
+          },
+          "sum": {
+            "id": 13
+          },
+          "avg": {
+            "id": 13
+          },
+          "min": {
+            "id": "13",
+            "title": "How to create item With Sub Tasks - Sub Task 1"
+          },
+          "max": {
+            "id": "13",
+            "title": "How to create item With Sub Tasks - Sub Task 1"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+</TabItem>
+</Tabs>
+
 
 ### With Filter
 
@@ -529,19 +772,21 @@ This example will aggregate all related `subTasks` that are not completed.
 {
   "data": {
     "todoItem": {
-      "subTasksAggregate": {
-        "count": {
-          "id": 2
-        },
-        "min": {
-          "id": "14",
-          "title": "How to create item With Sub Tasks - Sub Task 2"
-        },
-        "max": {
-          "id": "15",
-          "title": "How to create item With Sub Tasks - Sub Task 3"
+      "subTasksAggregate": [
+        {
+          "count": {
+            "id": 2
+          },
+          "min": {
+            "id": "14",
+            "title": "How to create item With Sub Tasks - Sub Task 2"
+          },
+          "max": {
+            "id": "15",
+            "title": "How to create item With Sub Tasks - Sub Task 3"
+          }
         }
-      }
+      ]
     }
   }
 }

--- a/documentation/docs/introduction/getting-started.md
+++ b/documentation/docs/introduction/getting-started.md
@@ -35,6 +35,7 @@ Nestjs-query is composed of multiple packages
 
 ## Migration Guides
 
+* [`v0.24.x` to `v0.25.x`](../migration-guides/v0.24.x-to-v0.25.x.mdx)
 * [`v0.23.x` to `v0.24.x`](../migration-guides/v0.23.x-to-v0.24.x.mdx)
 * [`v0.22.x` to `v0.23.x`](../migration-guides/v0.22.x-to-v0.23.x.mdx)
 * [`v0.15.x` to `v0.16.x`](../migration-guides/v0.15.x-to-v0.16.x.mdx)

--- a/documentation/docs/migration-guides/v0.24.x-to-v0.25.x.mdx
+++ b/documentation/docs/migration-guides/v0.24.x-to-v0.25.x.mdx
@@ -1,0 +1,200 @@
+---
+title: v0.24.x to v0.25.x
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+## Aggregate Queryies Return Arrays
+
+In versions prior to `v0.24.0` aggregate queries returned a single response with just the aggregated values. In `v0.25.0` we have introduced a new `groupBy` option that requires aggregates to return arrays.
+
+When using aggregates without the groupBy the response will always contain a single record with your aggregated
+values. If you specify a `groupBy` you will get a response with a distinct group and the corresponding aggregated
+values.
+
+Given the following query
+
+```graphql
+{
+  todoItemAggregate {
+    count {
+      id
+    }
+    sum {
+      id
+    }
+    avg {
+      id
+    }
+    min {
+      id
+      title
+      created
+    }
+    max {
+      id
+      title
+      created
+    }
+  }
+}
+```
+
+### Old
+
+The old response would look like
+
+```json
+{
+  "data": {
+    "todoItemAggregate": {
+      "count": {
+        "id": 5
+      },
+      "sum": {
+        "id": 15
+      },
+      "avg": {
+        "id": 3
+      },
+      "min": {
+        "id": "1",
+        "title": "Add Todo Item Resolver",
+        "created": "2021-03-29T06:51:26.061Z"
+      },
+      "max": {
+        "id": "5",
+        "title": "How to create item With Sub Tasks",
+        "created": "2021-03-29T06:51:26.061Z"
+      }
+    }
+  }
+}
+```
+
+### New
+The new response will look like
+```json
+{
+  "data": {
+    "todoItemAggregate": [
+      {
+        "count": {
+          "id": 5
+        },
+        "sum": {
+          "id": 15
+        },
+        "avg": {
+          "id": 3
+        },
+        "min": {
+          "id": "1",
+          "title": "Add Todo Item Resolver",
+          "created": "2021-03-29T06:51:26.061Z"
+        },
+        "max": {
+          "id": "5",
+          "title": "How to create item With Sub Tasks",
+          "created": "2021-03-29T06:51:26.061Z"
+        }
+      }
+    ]
+  }
+}
+```
+
+## New Aggregate GroupBy
+
+The new response format really shines when using the `groupBy` query
+
+Given the following aggregate grouping on `completed`
+
+```graphql {3-5}
+{
+  todoItemAggregate {
+    groupBy {
+      completed
+    }
+    count {
+      id
+    }
+    sum {
+      id
+    }
+    avg {
+      id
+    }
+    min {
+      id
+      title
+      created
+    }
+    max {
+      id
+      title
+      created
+    }
+  }
+}
+```
+
+You'll get the following response with record for each distinct group
+
+```json
+{
+  "data": {
+    "todoItemAggregate": [
+      {
+        "groupBy": {
+          "completed": false
+        },
+        "count": {
+          "id": 4
+        },
+        "sum": {
+          "id": 14
+        },
+        "avg": {
+          "id": 3.5
+        },
+        "min": {
+          "id": "2",
+          "title": "Add Todo Item Resolver",
+          "created": "2021-03-29T06:51:26.061Z"
+        },
+        "max": {
+          "id": "5",
+          "title": "How to create item With Sub Tasks",
+          "created": "2021-03-29T06:51:26.061Z"
+        }
+      },
+      {
+        "groupBy": {
+          "completed": true
+        },
+        "count": {
+          "id": 1
+        },
+        "sum": {
+          "id": 1
+        },
+        "avg": {
+          "id": 1
+        },
+        "min": {
+          "id": "1",
+          "title": "Create Nest App",
+          "created": "2021-03-29T06:51:26.061Z"
+        },
+        "max": {
+          "id": "1",
+          "title": "Create Nest App",
+          "created": "2021-03-29T06:51:26.061Z"
+        }
+      }
+    ]
+  }
+}
+```

--- a/documentation/docs/migration-guides/v0.24.x-to-v0.25.x.mdx
+++ b/documentation/docs/migration-guides/v0.24.x-to-v0.25.x.mdx
@@ -5,7 +5,7 @@ title: v0.24.x to v0.25.x
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-## Aggregate Queryies Return Arrays
+## Aggregate Queries Return Arrays
 
 In versions prior to `v0.24.0` aggregate queries returned a single response with just the aggregated values. In `v0.25.0` we have introduced a new `groupBy` option that requires aggregates to return arrays.
 

--- a/documentation/docs/persistence/services.mdx
+++ b/documentation/docs/persistence/services.mdx
@@ -387,17 +387,19 @@ const aggregateResponse = await this.service.aggregate({}, {
 The response will look like the following
 
 ```ts
-{
-  count: {
-    id: 10
-  },
-  min: {
-    title: 'Aggregate Todo Items'
-  },
-  min: {
-    title: 'Query Todo Items'
-  },
-}
+[
+  {
+    count: {
+      id: 10
+    },
+    min: {
+      title: 'Aggregate Todo Items'
+    },
+    min: {
+      title: 'Query Todo Items'
+    },
+  }
+]
 ```
 
 In this example we'll aggregate on all completed TodoItems

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -62,6 +62,7 @@ module.exports = {
     ],
     Utilities: ['utilities/query-helpers'],
     'Migration Guides': [
+      'migration-guides/v0.24.x-to-v0.25.x',
       'migration-guides/v0.23.x-to-v0.24.x',
       'migration-guides/v0.22.x-to-v0.23.x',
       'migration-guides/v0.15.x-to-v0.16.x',

--- a/examples/auth/e2e/sub-task.resolver.spec.ts
+++ b/examples/auth/e2e/sub-task.resolver.spec.ts
@@ -434,19 +434,21 @@ describe('SubTaskResolver (auth - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.subTaskAggregate;
-          expect(res).toEqual({
-            count: { id: 15, title: 15, description: 0, completed: 15, todoItemId: 15 },
-            sum: { id: 120 },
-            avg: { id: 8 },
-            min: { id: '1', title: 'Add Todo Item Resolver - Sub Task 1', description: null, todoItemId: '1' },
-            max: {
-              id: '15',
-              title: 'How to create item With Sub Tasks - Sub Task 3',
-              description: null,
-              todoItemId: '5',
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.subTaskAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 15, title: 15, description: 0, completed: 15, todoItemId: 15 },
+              sum: { id: 120 },
+              avg: { id: 8 },
+              min: { id: '1', title: 'Add Todo Item Resolver - Sub Task 1', description: null, todoItemId: '1' },
+              max: {
+                id: '15',
+                title: 'How to create item With Sub Tasks - Sub Task 3',
+                description: null,
+                todoItemId: '5',
+              },
             },
-          });
+          ]);
         }));
 
     it(`should allow filtering`, () =>
@@ -464,19 +466,21 @@ describe('SubTaskResolver (auth - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.subTaskAggregate;
-          expect(res).toEqual({
-            count: { id: 5, title: 5, description: 0, completed: 5, todoItemId: 5 },
-            sum: { id: 35 },
-            avg: { id: 7 },
-            min: { id: '1', title: 'Add Todo Item Resolver - Sub Task 1', description: null, todoItemId: '1' },
-            max: {
-              id: '13',
-              title: 'How to create item With Sub Tasks - Sub Task 1',
-              description: null,
-              todoItemId: '5',
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.subTaskAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 5, title: 5, description: 0, completed: 5, todoItemId: 5 },
+              sum: { id: 35 },
+              avg: { id: 7 },
+              min: { id: '1', title: 'Add Todo Item Resolver - Sub Task 1', description: null, todoItemId: '1' },
+              max: {
+                id: '13',
+                title: 'How to create item With Sub Tasks - Sub Task 1',
+                description: null,
+                todoItemId: '5',
+              },
             },
-          });
+          ]);
         }));
   });
 

--- a/examples/auth/e2e/tag.resolver.spec.ts
+++ b/examples/auth/e2e/tag.resolver.spec.ts
@@ -156,14 +156,16 @@ describe('TagResolver (auth - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const agg: AggregateResponse<TodoItemDTO> = body.data.tag.todoItemsAggregate;
-          expect(agg).toEqual({
-            avg: { id: 1.5 },
-            count: { completed: 2, created: 2, description: 0, id: 2, title: 2, updated: 2 },
-            max: { description: null, id: '2', title: 'Create Nest App' },
-            min: { description: null, id: '1', title: 'Create Entity' },
-            sum: { id: 3 },
-          });
+          const agg: AggregateResponse<TodoItemDTO>[] = body.data.tag.todoItemsAggregate;
+          expect(agg).toEqual([
+            {
+              avg: { id: 1.5 },
+              count: { completed: 2, created: 2, description: 0, id: 2, title: 2, updated: 2 },
+              max: { description: null, id: '2', title: 'Create Nest App' },
+              min: { description: null, id: '1', title: 'Create Entity' },
+              sum: { id: 3 },
+            },
+          ]);
         }));
   });
 
@@ -393,14 +395,16 @@ describe('TagResolver (auth - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.tagAggregate;
-          expect(res).toEqual({
-            count: { id: 5, name: 5, created: 5, updated: 5 },
-            sum: { id: 15 },
-            avg: { id: 3 },
-            min: { id: '1', name: 'Blocked' },
-            max: { id: '5', name: 'Work' },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.tagAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 5, name: 5, created: 5, updated: 5 },
+              sum: { id: 15 },
+              avg: { id: 3 },
+              min: { id: '1', name: 'Blocked' },
+              max: { id: '5', name: 'Work' },
+            },
+          ]);
         }));
 
     it(`should allow filtering`, () =>
@@ -418,14 +422,16 @@ describe('TagResolver (auth - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.tagAggregate;
-          expect(res).toEqual({
-            count: { id: 3, name: 3, created: 3, updated: 3 },
-            sum: { id: 9 },
-            avg: { id: 3 },
-            min: { id: '1', name: 'Blocked' },
-            max: { id: '5', name: 'Work' },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.tagAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 3, name: 3, created: 3, updated: 3 },
+              sum: { id: 9 },
+              avg: { id: 3 },
+              min: { id: '1', name: 'Blocked' },
+              max: { id: '5', name: 'Work' },
+            },
+          ]);
         }));
   });
 

--- a/examples/auth/e2e/todo-item.resolver.spec.ts
+++ b/examples/auth/e2e/todo-item.resolver.spec.ts
@@ -163,14 +163,16 @@ describe('TodoItemResolver (auth - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const agg: AggregateResponse<TagDTO> = body.data.todoItem.subTasksAggregate;
-          expect(agg).toEqual({
-            avg: { id: 2 },
-            count: { completed: 3, description: 0, id: 3, title: 3, todoItemId: 3 },
-            max: { description: null, id: '3', title: 'Create Nest App - Sub Task 3', todoItemId: '1' },
-            min: { description: null, id: '1', title: 'Create Nest App - Sub Task 1', todoItemId: '1' },
-            sum: { id: 6 },
-          });
+          const agg: AggregateResponse<TagDTO>[] = body.data.todoItem.subTasksAggregate;
+          expect(agg).toEqual([
+            {
+              avg: { id: 2 },
+              count: { completed: 3, description: 0, id: 3, title: 3, todoItemId: 3 },
+              max: { description: null, id: '3', title: 'Create Nest App - Sub Task 3', todoItemId: '1' },
+              min: { description: null, id: '1', title: 'Create Nest App - Sub Task 1', todoItemId: '1' },
+              sum: { id: 6 },
+            },
+          ]);
         }));
 
     it(`should return tags as a connection`, () =>
@@ -221,14 +223,16 @@ describe('TodoItemResolver (auth - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const agg: AggregateResponse<TagDTO> = body.data.todoItem.tagsAggregate;
-          expect(agg).toEqual({
-            avg: { id: 1.5 },
-            count: { created: 2, id: 2, name: 2, updated: 2 },
-            max: { id: '2', name: 'Urgent' },
-            min: { id: '1', name: 'Home' },
-            sum: { id: 3 },
-          });
+          const agg: AggregateResponse<TagDTO>[] = body.data.todoItem.tagsAggregate;
+          expect(agg).toEqual([
+            {
+              avg: { id: 1.5 },
+              count: { created: 2, id: 2, name: 2, updated: 2 },
+              max: { id: '2', name: 'Urgent' },
+              min: { id: '1', name: 'Home' },
+              sum: { id: 3 },
+            },
+          ]);
         }));
   });
 
@@ -537,14 +541,16 @@ describe('TodoItemResolver (auth - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.todoItemAggregate;
-          expect(res).toEqual({
-            avg: { id: 3 },
-            count: { completed: 5, created: 5, description: 0, id: 5, title: 5, updated: 5 },
-            max: { description: null, id: '5', title: 'How to create item With Sub Tasks' },
-            min: { description: null, id: '1', title: 'Add Todo Item Resolver' },
-            sum: { id: 15 },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.todoItemAggregate;
+          expect(res).toEqual([
+            {
+              avg: { id: 3 },
+              count: { completed: 5, created: 5, description: 0, id: 5, title: 5, updated: 5 },
+              max: { description: null, id: '5', title: 'How to create item With Sub Tasks' },
+              min: { description: null, id: '1', title: 'Add Todo Item Resolver' },
+              sum: { id: 15 },
+            },
+          ]);
         }));
 
     it(`should allow filtering`, () =>
@@ -562,14 +568,16 @@ describe('TodoItemResolver (auth - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.todoItemAggregate;
-          expect(res).toEqual({
-            count: { id: 4, title: 4, description: 0, completed: 4, created: 4, updated: 4 },
-            sum: { id: 14 },
-            avg: { id: 3.5 },
-            min: { id: '2', title: 'Add Todo Item Resolver', description: null },
-            max: { id: '5', title: 'How to create item With Sub Tasks', description: null },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.todoItemAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 4, title: 4, description: 0, completed: 4, created: 4, updated: 4 },
+              sum: { id: 14 },
+              avg: { id: 3.5 },
+              min: { id: '2', title: 'Add Todo Item Resolver', description: null },
+              max: { id: '5', title: 'How to create item With Sub Tasks', description: null },
+            },
+          ]);
         }));
   });
 

--- a/examples/mongoose/e2e/sub-task.resolver.spec.ts
+++ b/examples/mongoose/e2e/sub-task.resolver.spec.ts
@@ -294,20 +294,22 @@ describe('SubTaskResolver (mongoose - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.subTaskAggregate;
-          expect(res).toEqual({
-            count: { id: 15, title: 15, description: 0, completed: 15 },
-            min: {
-              id: SUB_TASKS[0].id,
-              title: 'Add Todo Item Resolver - Sub Task 1',
-              description: null,
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.subTaskAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 15, title: 15, description: 0, completed: 15 },
+              min: {
+                id: SUB_TASKS[0].id,
+                title: 'Add Todo Item Resolver - Sub Task 1',
+                description: null,
+              },
+              max: {
+                id: SUB_TASKS[SUB_TASKS.length - 1].id,
+                title: 'How to create item With Sub Tasks - Sub Task 3',
+                description: null,
+              },
             },
-            max: {
-              id: SUB_TASKS[SUB_TASKS.length - 1].id,
-              title: 'How to create item With Sub Tasks - Sub Task 3',
-              description: null,
-            },
-          });
+          ]);
         }));
 
     it(`should allow filtering`, () =>
@@ -324,16 +326,18 @@ describe('SubTaskResolver (mongoose - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.subTaskAggregate;
-          expect(res).toEqual({
-            count: { id: 5, title: 5, description: 0, completed: 5 },
-            min: { id: SUB_TASKS[0].id, title: 'Add Todo Item Resolver - Sub Task 1', description: null },
-            max: {
-              id: SUB_TASKS[12].id,
-              title: 'How to create item With Sub Tasks - Sub Task 1',
-              description: null,
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.subTaskAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 5, title: 5, description: 0, completed: 5 },
+              min: { id: SUB_TASKS[0].id, title: 'Add Todo Item Resolver - Sub Task 1', description: null },
+              max: {
+                id: SUB_TASKS[12].id,
+                title: 'How to create item With Sub Tasks - Sub Task 1',
+                description: null,
+              },
             },
-          });
+          ]);
         }));
   });
 

--- a/examples/mongoose/e2e/tag.resolver.spec.ts
+++ b/examples/mongoose/e2e/tag.resolver.spec.ts
@@ -119,12 +119,14 @@ describe('TagResolver (mongoose - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const agg: AggregateResponse<TodoItemDTO> = body.data.tag.todoItemsAggregate;
-          expect(agg).toEqual({
-            count: { completed: 2, createdAt: 2, description: 0, id: 2, title: 2, updatedAt: 2 },
-            max: { description: null, id: TODO_ITEMS[1].id, title: 'Create Nest App' },
-            min: { description: null, id: TODO_ITEMS[0].id, title: 'Create Entity' },
-          });
+          const agg: AggregateResponse<TodoItemDTO>[] = body.data.tag.todoItemsAggregate;
+          expect(agg).toEqual([
+            {
+              count: { completed: 2, createdAt: 2, description: 0, id: 2, title: 2, updatedAt: 2 },
+              max: { description: null, id: TODO_ITEMS[1].id, title: 'Create Nest App' },
+              min: { description: null, id: TODO_ITEMS[0].id, title: 'Create Entity' },
+            },
+          ]);
         }));
   });
 
@@ -299,12 +301,14 @@ describe('TagResolver (mongoose - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.tagAggregate;
-          expect(res).toEqual({
-            count: { id: 5, name: 5, createdAt: 5, updatedAt: 5 },
-            min: { id: TAGS[0].id, name: 'Blocked' },
-            max: { id: TAGS[4].id, name: 'Work' },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.tagAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 5, name: 5, createdAt: 5, updatedAt: 5 },
+              min: { id: TAGS[0].id, name: 'Blocked' },
+              max: { id: TAGS[4].id, name: 'Work' },
+            },
+          ]);
         }));
 
     it(`should allow filtering`, () =>
@@ -321,12 +325,14 @@ describe('TagResolver (mongoose - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.tagAggregate;
-          expect(res).toEqual({
-            count: { id: 3, name: 3, createdAt: 3, updatedAt: 3 },
-            min: { id: '5f74ed2686b2bae7bf4b4aab', name: 'Blocked' },
-            max: { id: '5f74ed2686b2bae7bf4b4aaf', name: 'Work' },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.tagAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 3, name: 3, createdAt: 3, updatedAt: 3 },
+              min: { id: '5f74ed2686b2bae7bf4b4aab', name: 'Blocked' },
+              max: { id: '5f74ed2686b2bae7bf4b4aaf', name: 'Work' },
+            },
+          ]);
         }));
   });
 

--- a/examples/mongoose/e2e/todo-item.resolver.spec.ts
+++ b/examples/mongoose/e2e/todo-item.resolver.spec.ts
@@ -143,12 +143,14 @@ describe('TodoItemResolver (mongoose - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const agg: AggregateResponse<TagDTO> = body.data.todoItem.subTasksAggregate;
-          expect(agg).toEqual({
-            count: { completed: 3, description: 0, id: 3, title: 3 },
-            max: { description: null, id: '5f74ed936c3afaeaadb8f31c', title: 'Create Nest App - Sub Task 3' },
-            min: { description: null, id: '5f74ed936c3afaeaadb8f31a', title: 'Create Nest App - Sub Task 1' },
-          });
+          const agg: AggregateResponse<TagDTO>[] = body.data.todoItem.subTasksAggregate;
+          expect(agg).toEqual([
+            {
+              count: { completed: 3, description: 0, id: 3, title: 3 },
+              max: { description: null, id: '5f74ed936c3afaeaadb8f31c', title: 'Create Nest App - Sub Task 3' },
+              min: { description: null, id: '5f74ed936c3afaeaadb8f31a', title: 'Create Nest App - Sub Task 1' },
+            },
+          ]);
         }));
 
     it(`should return tags as a connection`, () =>
@@ -197,12 +199,14 @@ describe('TodoItemResolver (mongoose - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const agg: AggregateResponse<TagDTO> = body.data.todoItem.tagsAggregate;
-          expect(agg).toEqual({
-            count: { createdAt: 2, id: 2, name: 2, updatedAt: 2 },
-            max: { id: '5f74ed2686b2bae7bf4b4aac', name: 'Urgent' },
-            min: { id: '5f74ed2686b2bae7bf4b4aab', name: 'Home' },
-          });
+          const agg: AggregateResponse<TagDTO>[] = body.data.todoItem.tagsAggregate;
+          expect(agg).toEqual([
+            {
+              count: { createdAt: 2, id: 2, name: 2, updatedAt: 2 },
+              max: { id: '5f74ed2686b2bae7bf4b4aac', name: 'Urgent' },
+              min: { id: '5f74ed2686b2bae7bf4b4aab', name: 'Home' },
+            },
+          ]);
         }));
   });
 
@@ -517,12 +521,49 @@ describe('TodoItemResolver (mongoose - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.todoItemAggregate;
-          expect(res).toEqual({
-            count: { completed: 5, createdAt: 5, description: 0, id: 5, title: 5, updatedAt: 5 },
-            max: { description: null, id: todoItemIds[4], title: 'How to create item With Sub Tasks' },
-            min: { description: null, id: todoItemIds[0], title: 'Add Todo Item Resolver' },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.todoItemAggregate;
+          expect(res).toEqual([
+            {
+              count: { completed: 5, createdAt: 5, description: 0, id: 5, title: 5, updatedAt: 5 },
+              max: { description: null, id: todoItemIds[4], title: 'How to create item With Sub Tasks' },
+              min: { description: null, id: todoItemIds[0], title: 'Add Todo Item Resolver' },
+            },
+          ]);
+        }));
+
+    it(`should return a aggregate response with groupBy`, () =>
+      request(app.getHttpServer())
+        .post('/graphql')
+        .set(AUTH_HEADER_NAME, config.auth.header)
+        .send({
+          operationName: null,
+          variables: {},
+          query: `{ 
+          todoItemAggregate {
+              groupBy {
+                completed
+              }
+              ${todoItemAggregateFields}
+            }
+        }`,
+        })
+        .expect(200)
+        .then(({ body }) => {
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.todoItemAggregate;
+          expect(res).toEqual([
+            {
+              groupBy: { completed: false },
+              count: { completed: 4, createdAt: 4, description: 0, id: 4, title: 4, updatedAt: 4 },
+              max: { description: null, id: todoItemIds[4], title: 'How to create item With Sub Tasks' },
+              min: { description: null, id: todoItemIds[1], title: 'Add Todo Item Resolver' },
+            },
+            {
+              groupBy: { completed: true },
+              count: { completed: 1, createdAt: 1, description: 0, id: 1, title: 1, updatedAt: 1 },
+              max: { description: null, id: todoItemIds[0], title: 'Create Nest App' },
+              min: { description: null, id: todoItemIds[0], title: 'Create Nest App' },
+            },
+          ]);
         }));
 
     it(`should allow filtering`, () =>
@@ -540,12 +581,14 @@ describe('TodoItemResolver (mongoose - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.todoItemAggregate;
-          expect(res).toEqual({
-            count: { id: 4, title: 4, description: 0, completed: 4, createdAt: 4, updatedAt: 4 },
-            min: { id: todoItemIds[1], title: 'Add Todo Item Resolver', description: null },
-            max: { id: todoItemIds[4], title: 'How to create item With Sub Tasks', description: null },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.todoItemAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 4, title: 4, description: 0, completed: 4, createdAt: 4, updatedAt: 4 },
+              min: { id: todoItemIds[1], title: 'Add Todo Item Resolver', description: null },
+              max: { id: todoItemIds[4], title: 'How to create item With Sub Tasks', description: null },
+            },
+          ]);
         }));
   });
 

--- a/examples/sequelize/e2e/sub-task.resolver.spec.ts
+++ b/examples/sequelize/e2e/sub-task.resolver.spec.ts
@@ -372,19 +372,21 @@ describe('SubTaskResolver (sequelize - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.subTaskAggregate;
-          expect(res).toEqual({
-            count: { id: 15, title: 15, description: 0, completed: 15, todoItemId: 15 },
-            sum: { id: 120 },
-            avg: { id: 8 },
-            min: { id: '1', title: 'Add Todo Item Resolver - Sub Task 1', description: null, todoItemId: 1 },
-            max: {
-              id: '15',
-              title: 'How to create item With Sub Tasks - Sub Task 3',
-              description: null,
-              todoItemId: 5,
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.subTaskAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 15, title: 15, description: 0, completed: 15, todoItemId: 15 },
+              sum: { id: 120 },
+              avg: { id: 8 },
+              min: { id: '1', title: 'Add Todo Item Resolver - Sub Task 1', description: null, todoItemId: 1 },
+              max: {
+                id: '15',
+                title: 'How to create item With Sub Tasks - Sub Task 3',
+                description: null,
+                todoItemId: 5,
+              },
             },
-          });
+          ]);
         }));
 
     it(`should allow filtering`, () =>
@@ -401,19 +403,21 @@ describe('SubTaskResolver (sequelize - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.subTaskAggregate;
-          expect(res).toEqual({
-            count: { id: 5, title: 5, description: 0, completed: 5, todoItemId: 5 },
-            sum: { id: 35 },
-            avg: { id: 7 },
-            min: { id: '1', title: 'Add Todo Item Resolver - Sub Task 1', description: null, todoItemId: 1 },
-            max: {
-              id: '13',
-              title: 'How to create item With Sub Tasks - Sub Task 1',
-              description: null,
-              todoItemId: 5,
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.subTaskAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 5, title: 5, description: 0, completed: 5, todoItemId: 5 },
+              sum: { id: 35 },
+              avg: { id: 7 },
+              min: { id: '1', title: 'Add Todo Item Resolver - Sub Task 1', description: null, todoItemId: 1 },
+              max: {
+                id: '13',
+                title: 'How to create item With Sub Tasks - Sub Task 1',
+                description: null,
+                todoItemId: 5,
+              },
             },
-          });
+          ]);
         }));
   });
 

--- a/examples/sequelize/e2e/tag.resolver.spec.ts
+++ b/examples/sequelize/e2e/tag.resolver.spec.ts
@@ -129,14 +129,16 @@ describe('TagResolver (sequelize - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const agg: AggregateResponse<TodoItemDTO> = body.data.tag.todoItemsAggregate;
-          expect(agg).toEqual({
-            avg: { id: 1.5 },
-            count: { completed: 2, created: 2, description: 0, id: 2, title: 2, updated: 2 },
-            max: { description: null, id: '2', title: 'Create Nest App' },
-            min: { description: null, id: '1', title: 'Create Entity' },
-            sum: { id: 3 },
-          });
+          const agg: AggregateResponse<TodoItemDTO>[] = body.data.tag.todoItemsAggregate;
+          expect(agg).toEqual([
+            {
+              avg: { id: 1.5 },
+              count: { completed: 2, created: 2, description: 0, id: 2, title: 2, updated: 2 },
+              max: { description: null, id: '2', title: 'Create Nest App' },
+              min: { description: null, id: '1', title: 'Create Entity' },
+              sum: { id: 3 },
+            },
+          ]);
         }));
   });
 
@@ -327,14 +329,16 @@ describe('TagResolver (sequelize - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.tagAggregate;
-          expect(res).toEqual({
-            count: { id: 5, name: 5, created: 5, updated: 5 },
-            sum: { id: 15 },
-            avg: { id: 3 },
-            min: { id: '1', name: 'Blocked' },
-            max: { id: '5', name: 'Work' },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.tagAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 5, name: 5, created: 5, updated: 5 },
+              sum: { id: 15 },
+              avg: { id: 3 },
+              min: { id: '1', name: 'Blocked' },
+              max: { id: '5', name: 'Work' },
+            },
+          ]);
         }));
 
     it(`should allow filtering`, () =>
@@ -351,14 +355,16 @@ describe('TagResolver (sequelize - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.tagAggregate;
-          expect(res).toEqual({
-            count: { id: 3, name: 3, created: 3, updated: 3 },
-            sum: { id: 9 },
-            avg: { id: 3 },
-            min: { id: '1', name: 'Blocked' },
-            max: { id: '5', name: 'Work' },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.tagAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 3, name: 3, created: 3, updated: 3 },
+              sum: { id: 9 },
+              avg: { id: 3 },
+              min: { id: '1', name: 'Blocked' },
+              max: { id: '5', name: 'Work' },
+            },
+          ]);
         }));
   });
 

--- a/examples/sequelize/e2e/todo-item.resolver.spec.ts
+++ b/examples/sequelize/e2e/todo-item.resolver.spec.ts
@@ -139,14 +139,16 @@ describe('TodoItemResolver (sequelize - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const agg: AggregateResponse<TagDTO> = body.data.todoItem.subTasksAggregate;
-          expect(agg).toEqual({
-            avg: { id: 2 },
-            count: { completed: 3, description: 0, id: 3, title: 3, todoItemId: 3 },
-            max: { description: null, id: '3', title: 'Create Nest App - Sub Task 3', todoItemId: 1 },
-            min: { description: null, id: '1', title: 'Create Nest App - Sub Task 1', todoItemId: 1 },
-            sum: { id: 6 },
-          });
+          const agg: AggregateResponse<TagDTO>[] = body.data.todoItem.subTasksAggregate;
+          expect(agg).toEqual([
+            {
+              avg: { id: 2 },
+              count: { completed: 3, description: 0, id: 3, title: 3, todoItemId: 3 },
+              max: { description: null, id: '3', title: 'Create Nest App - Sub Task 3', todoItemId: 1 },
+              min: { description: null, id: '1', title: 'Create Nest App - Sub Task 1', todoItemId: 1 },
+              sum: { id: 6 },
+            },
+          ]);
         }));
 
     it(`should return tags as a connection`, () =>
@@ -195,14 +197,16 @@ describe('TodoItemResolver (sequelize - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const agg: AggregateResponse<TagDTO> = body.data.todoItem.tagsAggregate;
-          expect(agg).toEqual({
-            avg: { id: 1.5 },
-            count: { created: 2, id: 2, name: 2, updated: 2 },
-            max: { id: '2', name: 'Urgent' },
-            min: { id: '1', name: 'Home' },
-            sum: { id: 3 },
-          });
+          const agg: AggregateResponse<TagDTO>[] = body.data.todoItem.tagsAggregate;
+          expect(agg).toEqual([
+            {
+              avg: { id: 1.5 },
+              count: { created: 2, id: 2, name: 2, updated: 2 },
+              max: { id: '2', name: 'Urgent' },
+              min: { id: '1', name: 'Home' },
+              sum: { id: 3 },
+            },
+          ]);
         }));
   });
 
@@ -487,14 +491,55 @@ describe('TodoItemResolver (sequelize - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.todoItemAggregate;
-          expect(res).toEqual({
-            avg: { id: 3 },
-            count: { completed: 5, created: 5, description: 0, id: 5, title: 5, updated: 5 },
-            max: { description: null, id: '5', title: 'How to create item With Sub Tasks' },
-            min: { description: null, id: '1', title: 'Add Todo Item Resolver' },
-            sum: { id: 15 },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.todoItemAggregate;
+          expect(res).toEqual([
+            {
+              avg: { id: 3 },
+              count: { completed: 5, created: 5, description: 0, id: 5, title: 5, updated: 5 },
+              max: { description: null, id: '5', title: 'How to create item With Sub Tasks' },
+              min: { description: null, id: '1', title: 'Add Todo Item Resolver' },
+              sum: { id: 15 },
+            },
+          ]);
+        }));
+
+    it(`should return a aggregate response with groupBy`, () =>
+      request(app.getHttpServer())
+        .post('/graphql')
+        .set(AUTH_HEADER_NAME, config.auth.header)
+        .send({
+          operationName: null,
+          variables: {},
+          query: `{ 
+          todoItemAggregate {
+              groupBy {
+                completed
+              }
+              ${todoItemAggregateFields}
+            }
+        }`,
+        })
+        .expect(200)
+        .then(({ body }) => {
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.todoItemAggregate;
+          expect(res).toEqual([
+            {
+              groupBy: { completed: false },
+              avg: { id: 3.5 },
+              count: { completed: 4, created: 4, description: 0, id: 4, title: 4, updated: 4 },
+              max: { description: null, id: '5', title: 'How to create item With Sub Tasks' },
+              min: { description: null, id: '2', title: 'Add Todo Item Resolver' },
+              sum: { id: 14 },
+            },
+            {
+              groupBy: { completed: true },
+              avg: { id: 1 },
+              count: { completed: 1, created: 1, description: 0, id: 1, title: 1, updated: 1 },
+              max: { description: null, id: '1', title: 'Create Nest App' },
+              min: { description: null, id: '1', title: 'Create Nest App' },
+              sum: { id: 1 },
+            },
+          ]);
         }));
 
     it(`should allow filtering`, () =>
@@ -512,14 +557,16 @@ describe('TodoItemResolver (sequelize - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.todoItemAggregate;
-          expect(res).toEqual({
-            count: { id: 4, title: 4, description: 0, completed: 4, created: 4, updated: 4 },
-            sum: { id: 14 },
-            avg: { id: 3.5 },
-            min: { id: '2', title: 'Add Todo Item Resolver', description: null },
-            max: { id: '5', title: 'How to create item With Sub Tasks', description: null },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.todoItemAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 4, title: 4, description: 0, completed: 4, created: 4, updated: 4 },
+              sum: { id: 14 },
+              avg: { id: 3.5 },
+              min: { id: '2', title: 'Add Todo Item Resolver', description: null },
+              max: { id: '5', title: 'How to create item With Sub Tasks', description: null },
+            },
+          ]);
         }));
   });
 

--- a/examples/typegoose/e2e/sub-task.resolver.spec.ts
+++ b/examples/typegoose/e2e/sub-task.resolver.spec.ts
@@ -186,35 +186,6 @@ describe('SubTaskResolver (typegoose - e2e)', () => {
           expect(edges.map((e) => e.node)).toEqual(toGraphqlSubTasks(SUB_TASKS.slice(0, 3)));
         }));
 
-    // it(`should allow querying on todoItem`, () => {
-    //   return request(app.getHttpServer())
-    //     .post('/graphql')
-    //     .send({
-    //       operationName: null,
-    //       variables: {},
-    //       query: `{
-    //       subTasks(filter: { todoItem: { title: { like: "Create Entity%" } } }) {
-    //         ${pageInfoField}
-    //         ${edgeNodes(subTaskFields)}
-    //         totalCount
-    //       }
-    //     }`,
-    //     })
-    //     .expect(200)
-    //     .then(({ body }) => {
-    //       const { edges, pageInfo, totalCount }: CursorConnectionType<SubTaskDTO> = body.data.subTasks;
-    //       expect(pageInfo).toEqual({
-    //         endCursor: 'eyJ0eXBlIjoia2V5c2V0IiwiZmllbGRzIjpbeyJmaWVsZCI6ImlkIiwidmFsdWUiOjl9XX0=',
-    //         hasNextPage: false,
-    //         hasPreviousPage: false,
-    //         startCursor: 'eyJ0eXBlIjoia2V5c2V0IiwiZmllbGRzIjpbeyJmaWVsZCI6ImlkIiwidmFsdWUiOjR9XX0=',
-    //       });
-    //       expect(totalCount).toBe(6);
-    //       expect(edges).toHaveLength(6);
-    //       expect(edges.map((e) => e.node)).toEqual(SUB_TASKS.slice(3, 9));
-    //     });
-    // });
-
     it(`should allow sorting`, () =>
       request(app.getHttpServer())
         .post('/graphql')

--- a/examples/typegoose/e2e/sub-task.resolver.spec.ts
+++ b/examples/typegoose/e2e/sub-task.resolver.spec.ts
@@ -323,20 +323,22 @@ describe('SubTaskResolver (typegoose - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.subTaskAggregate;
-          expect(res).toEqual({
-            count: { id: 15, title: 15, description: 0, completed: 15 },
-            min: {
-              id: SUB_TASKS[0].id,
-              title: 'Add Todo Item Resolver - Sub Task 1',
-              description: null,
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.subTaskAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 15, title: 15, description: 0, completed: 15 },
+              min: {
+                id: SUB_TASKS[0].id,
+                title: 'Add Todo Item Resolver - Sub Task 1',
+                description: null,
+              },
+              max: {
+                id: SUB_TASKS[SUB_TASKS.length - 1].id,
+                title: 'How to create item With Sub Tasks - Sub Task 3',
+                description: null,
+              },
             },
-            max: {
-              id: SUB_TASKS[SUB_TASKS.length - 1].id,
-              title: 'How to create item With Sub Tasks - Sub Task 3',
-              description: null,
-            },
-          });
+          ]);
         }));
 
     it(`should allow filtering`, () =>
@@ -353,16 +355,18 @@ describe('SubTaskResolver (typegoose - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.subTaskAggregate;
-          expect(res).toEqual({
-            count: { id: 5, title: 5, description: 0, completed: 5 },
-            min: { id: SUB_TASKS[0].id, title: 'Add Todo Item Resolver - Sub Task 1', description: null },
-            max: {
-              id: SUB_TASKS[12].id,
-              title: 'How to create item With Sub Tasks - Sub Task 1',
-              description: null,
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.subTaskAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 5, title: 5, description: 0, completed: 5 },
+              min: { id: SUB_TASKS[0].id, title: 'Add Todo Item Resolver - Sub Task 1', description: null },
+              max: {
+                id: SUB_TASKS[12].id,
+                title: 'How to create item With Sub Tasks - Sub Task 1',
+                description: null,
+              },
             },
-          });
+          ]);
         }));
   });
 

--- a/examples/typegoose/e2e/tag.resolver.spec.ts
+++ b/examples/typegoose/e2e/tag.resolver.spec.ts
@@ -193,35 +193,6 @@ describe('TagResolver (typegoose - e2e)', () => {
           expect(edges.map((e) => e.node)).toEqual(TAGS.slice(0, 3));
         }));
 
-    // it(`should allow querying on todoItems`, () => {
-    //   return request(app.getHttpServer())
-    //     .post('/graphql')
-    //     .send({
-    //       operationName: null,
-    //       variables: {},
-    //       query: `{
-    //       tags(filter: { todoItems: { title: { like: "Create Entity%" } } }, sorting: [{field: id, direction: ASC}]) {
-    //         ${pageInfoField}
-    //         ${edgeNodes(tagFields)}
-    //         totalCount
-    //       }
-    //     }`,
-    //     })
-    //     .expect(200)
-    //     .then(({ body }) => {
-    //       const { edges, pageInfo, totalCount }: CursorConnectionType<TagDTO> = body.data.tags;
-    //       expect(pageInfo).toEqual({
-    //         endCursor: 'eyJ0eXBlIjoia2V5c2V0IiwiZmllbGRzIjpbeyJmaWVsZCI6ImlkIiwidmFsdWUiOjV9XX0=',
-    //         hasNextPage: false,
-    //         hasPreviousPage: false,
-    //         startCursor: 'eyJ0eXBlIjoia2V5c2V0IiwiZmllbGRzIjpbeyJmaWVsZCI6ImlkIiwidmFsdWUiOjF9XX0=',
-    //       });
-    //       expect(totalCount).toBe(3);
-    //       expect(edges).toHaveLength(3);
-    //       expect(edges.map((e) => e.node)).toEqual([TAGS[0], TAGS[2], TAGS[4]]);
-    //     });
-    // });
-
     it(`should allow sorting`, () =>
       request(app.getHttpServer())
         .post('/graphql')

--- a/examples/typegoose/e2e/tag.resolver.spec.ts
+++ b/examples/typegoose/e2e/tag.resolver.spec.ts
@@ -119,12 +119,14 @@ describe('TagResolver (typegoose - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const agg: AggregateResponse<TodoItemDTO> = body.data.tag.todoItemsAggregate;
-          expect(agg).toEqual({
-            count: { completed: 2, createdAt: 2, description: 0, id: 2, title: 2, updatedAt: 2 },
-            max: { description: null, id: TODO_ITEMS[1].id, title: 'Create Nest App' },
-            min: { description: null, id: TODO_ITEMS[0].id, title: 'Create Entity' },
-          });
+          const agg: AggregateResponse<TodoItemDTO>[] = body.data.tag.todoItemsAggregate;
+          expect(agg).toEqual([
+            {
+              count: { completed: 2, createdAt: 2, description: 0, id: 2, title: 2, updatedAt: 2 },
+              max: { description: null, id: TODO_ITEMS[1].id, title: 'Create Nest App' },
+              min: { description: null, id: TODO_ITEMS[0].id, title: 'Create Entity' },
+            },
+          ]);
         }));
   });
 
@@ -328,12 +330,14 @@ describe('TagResolver (typegoose - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.tagAggregate;
-          expect(res).toEqual({
-            count: { id: 5, name: 5, createdAt: 5, updatedAt: 5 },
-            min: { id: TAGS[0].id, name: 'Blocked' },
-            max: { id: TAGS[4].id, name: 'Work' },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.tagAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 5, name: 5, createdAt: 5, updatedAt: 5 },
+              min: { id: TAGS[0].id, name: 'Blocked' },
+              max: { id: TAGS[4].id, name: 'Work' },
+            },
+          ]);
         }));
 
     it(`should allow filtering`, () =>
@@ -350,12 +354,14 @@ describe('TagResolver (typegoose - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.tagAggregate;
-          expect(res).toEqual({
-            count: { id: 3, name: 3, createdAt: 3, updatedAt: 3 },
-            min: { id: '5f74ed2686b2bae7bf4b4aab', name: 'Blocked' },
-            max: { id: '5f74ed2686b2bae7bf4b4aaf', name: 'Work' },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.tagAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 3, name: 3, createdAt: 3, updatedAt: 3 },
+              min: { id: '5f74ed2686b2bae7bf4b4aab', name: 'Blocked' },
+              max: { id: '5f74ed2686b2bae7bf4b4aaf', name: 'Work' },
+            },
+          ]);
         }));
   });
 

--- a/examples/typegoose/e2e/todo-item.resolver.spec.ts
+++ b/examples/typegoose/e2e/todo-item.resolver.spec.ts
@@ -143,12 +143,14 @@ describe('TodoItemResolver (typegoose - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const agg: AggregateResponse<TagDTO> = body.data.todoItem.subTasksAggregate;
-          expect(agg).toEqual({
-            count: { completed: 3, description: 0, id: 3, title: 3 },
-            max: { description: null, id: '5f74ed936c3afaeaadb8f31c', title: 'Create Nest App - Sub Task 3' },
-            min: { description: null, id: '5f74ed936c3afaeaadb8f31a', title: 'Create Nest App - Sub Task 1' },
-          });
+          const agg: AggregateResponse<TagDTO>[] = body.data.todoItem.subTasksAggregate;
+          expect(agg).toEqual([
+            {
+              count: { completed: 3, description: 0, id: 3, title: 3 },
+              max: { description: null, id: '5f74ed936c3afaeaadb8f31c', title: 'Create Nest App - Sub Task 3' },
+              min: { description: null, id: '5f74ed936c3afaeaadb8f31a', title: 'Create Nest App - Sub Task 1' },
+            },
+          ]);
         }));
 
     it(`should return tags as a connection`, () =>
@@ -197,12 +199,14 @@ describe('TodoItemResolver (typegoose - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const agg: AggregateResponse<TagDTO> = body.data.todoItem.tagsAggregate;
-          expect(agg).toEqual({
-            count: { createdAt: 2, id: 2, name: 2, updatedAt: 2 },
-            max: { id: '5f74ed2686b2bae7bf4b4aac', name: 'Urgent' },
-            min: { id: '5f74ed2686b2bae7bf4b4aab', name: 'Home' },
-          });
+          const agg: AggregateResponse<TagDTO>[] = body.data.todoItem.tagsAggregate;
+          expect(agg).toEqual([
+            {
+              count: { createdAt: 2, id: 2, name: 2, updatedAt: 2 },
+              max: { id: '5f74ed2686b2bae7bf4b4aac', name: 'Urgent' },
+              min: { id: '5f74ed2686b2bae7bf4b4aab', name: 'Home' },
+            },
+          ]);
         }));
   });
 
@@ -583,12 +587,49 @@ describe('TodoItemResolver (typegoose - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.todoItemAggregate;
-          expect(res).toEqual({
-            count: { completed: 5, createdAt: 5, description: 0, id: 5, title: 5, updatedAt: 5 },
-            max: { description: null, id: todoItemIds[4], title: 'How to create item With Sub Tasks' },
-            min: { description: null, id: todoItemIds[0], title: 'Add Todo Item Resolver' },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.todoItemAggregate;
+          expect(res).toEqual([
+            {
+              count: { completed: 5, createdAt: 5, description: 0, id: 5, title: 5, updatedAt: 5 },
+              max: { description: null, id: todoItemIds[4], title: 'How to create item With Sub Tasks' },
+              min: { description: null, id: todoItemIds[0], title: 'Add Todo Item Resolver' },
+            },
+          ]);
+        }));
+
+    it(`should return a aggregate response with groupBy`, () =>
+      request(app.getHttpServer())
+        .post('/graphql')
+        .set(AUTH_HEADER_NAME, config.auth.header)
+        .send({
+          operationName: null,
+          variables: {},
+          query: `{ 
+          todoItemAggregate {
+              groupBy {
+                completed
+              }
+              ${todoItemAggregateFields}
+            }
+        }`,
+        })
+        .expect(200)
+        .then(({ body }) => {
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.todoItemAggregate;
+          expect(res).toEqual([
+            {
+              groupBy: { completed: false },
+              count: { completed: 4, createdAt: 4, description: 0, id: 4, title: 4, updatedAt: 4 },
+              max: { description: null, id: todoItemIds[4], title: 'How to create item With Sub Tasks' },
+              min: { description: null, id: todoItemIds[1], title: 'Add Todo Item Resolver' },
+            },
+            {
+              groupBy: { completed: true },
+              count: { completed: 1, createdAt: 1, description: 0, id: 1, title: 1, updatedAt: 1 },
+              max: { description: null, id: todoItemIds[0], title: 'Create Nest App' },
+              min: { description: null, id: todoItemIds[0], title: 'Create Nest App' },
+            },
+          ]);
         }));
 
     it(`should allow filtering`, () =>
@@ -606,12 +647,14 @@ describe('TodoItemResolver (typegoose - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.todoItemAggregate;
-          expect(res).toEqual({
-            count: { id: 4, title: 4, description: 0, completed: 4, createdAt: 4, updatedAt: 4 },
-            min: { id: todoItemIds[1], title: 'Add Todo Item Resolver', description: null },
-            max: { id: todoItemIds[4], title: 'How to create item With Sub Tasks', description: null },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.todoItemAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 4, title: 4, description: 0, completed: 4, createdAt: 4, updatedAt: 4 },
+              min: { id: todoItemIds[1], title: 'Add Todo Item Resolver', description: null },
+              max: { id: todoItemIds[4], title: 'How to create item With Sub Tasks', description: null },
+            },
+          ]);
         }));
   });
 

--- a/examples/typeorm/e2e/sub-task.resolver.spec.ts
+++ b/examples/typeorm/e2e/sub-task.resolver.spec.ts
@@ -372,19 +372,21 @@ describe('SubTaskResolver (typeorm - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.subTaskAggregate;
-          expect(res).toEqual({
-            count: { id: 15, title: 15, description: 0, completed: 15, todoItemId: 15 },
-            sum: { id: 120 },
-            avg: { id: 8 },
-            min: { id: '1', title: 'Add Todo Item Resolver - Sub Task 1', description: null, todoItemId: '1' },
-            max: {
-              id: '15',
-              title: 'How to create item With Sub Tasks - Sub Task 3',
-              description: null,
-              todoItemId: '5',
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.subTaskAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 15, title: 15, description: 0, completed: 15, todoItemId: 15 },
+              sum: { id: 120 },
+              avg: { id: 8 },
+              min: { id: '1', title: 'Add Todo Item Resolver - Sub Task 1', description: null, todoItemId: '1' },
+              max: {
+                id: '15',
+                title: 'How to create item With Sub Tasks - Sub Task 3',
+                description: null,
+                todoItemId: '5',
+              },
             },
-          });
+          ]);
         }));
 
     it(`should allow filtering`, () =>
@@ -401,19 +403,21 @@ describe('SubTaskResolver (typeorm - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.subTaskAggregate;
-          expect(res).toEqual({
-            count: { id: 5, title: 5, description: 0, completed: 5, todoItemId: 5 },
-            sum: { id: 35 },
-            avg: { id: 7 },
-            min: { id: '1', title: 'Add Todo Item Resolver - Sub Task 1', description: null, todoItemId: '1' },
-            max: {
-              id: '13',
-              title: 'How to create item With Sub Tasks - Sub Task 1',
-              description: null,
-              todoItemId: '5',
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.subTaskAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 5, title: 5, description: 0, completed: 5, todoItemId: 5 },
+              sum: { id: 35 },
+              avg: { id: 7 },
+              min: { id: '1', title: 'Add Todo Item Resolver - Sub Task 1', description: null, todoItemId: '1' },
+              max: {
+                id: '13',
+                title: 'How to create item With Sub Tasks - Sub Task 1',
+                description: null,
+                todoItemId: '5',
+              },
             },
-          });
+          ]);
         }));
   });
 

--- a/examples/typeorm/e2e/tag.resolver.spec.ts
+++ b/examples/typeorm/e2e/tag.resolver.spec.ts
@@ -131,14 +131,16 @@ describe('TagResolver (typeorm - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const agg: AggregateResponse<TodoItemDTO> = body.data.tag.todoItemsAggregate;
-          expect(agg).toEqual({
-            avg: { id: 1.5 },
-            count: { completed: 2, created: 2, description: 0, id: 2, title: 2, updated: 2 },
-            max: { description: null, id: '2', title: 'Create Nest App' },
-            min: { description: null, id: '1', title: 'Create Entity' },
-            sum: { id: 3 },
-          });
+          const agg: AggregateResponse<TodoItemDTO>[] = body.data.tag.todoItemsAggregate;
+          expect(agg).toEqual([
+            {
+              avg: { id: 1.5 },
+              count: { completed: 2, created: 2, description: 0, id: 2, title: 2, updated: 2 },
+              max: { description: null, id: '2', title: 'Create Nest App' },
+              min: { description: null, id: '1', title: 'Create Entity' },
+              sum: { id: 3 },
+            },
+          ]);
         }));
   });
 
@@ -329,14 +331,16 @@ describe('TagResolver (typeorm - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.tagAggregate;
-          expect(res).toEqual({
-            count: { id: 5, name: 5, created: 5, updated: 5 },
-            sum: { id: 15 },
-            avg: { id: 3 },
-            min: { id: '1', name: 'Blocked' },
-            max: { id: '5', name: 'Work' },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.tagAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 5, name: 5, created: 5, updated: 5 },
+              sum: { id: 15 },
+              avg: { id: 3 },
+              min: { id: '1', name: 'Blocked' },
+              max: { id: '5', name: 'Work' },
+            },
+          ]);
         }));
 
     it(`should allow filtering`, () =>
@@ -353,14 +357,16 @@ describe('TagResolver (typeorm - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.tagAggregate;
-          expect(res).toEqual({
-            count: { id: 3, name: 3, created: 3, updated: 3 },
-            sum: { id: 9 },
-            avg: { id: 3 },
-            min: { id: '1', name: 'Blocked' },
-            max: { id: '5', name: 'Work' },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.tagAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 3, name: 3, created: 3, updated: 3 },
+              sum: { id: 9 },
+              avg: { id: 3 },
+              min: { id: '1', name: 'Blocked' },
+              max: { id: '5', name: 'Work' },
+            },
+          ]);
         }));
   });
 

--- a/examples/typeorm/e2e/todo-item.resolver.spec.ts
+++ b/examples/typeorm/e2e/todo-item.resolver.spec.ts
@@ -140,14 +140,16 @@ describe('TodoItemResolver (typeorm - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const agg: AggregateResponse<TagDTO> = body.data.todoItem.subTasksAggregate;
-          expect(agg).toEqual({
-            avg: { id: 2 },
-            count: { completed: 3, description: 0, id: 3, title: 3, todoItemId: 3 },
-            max: { description: null, id: '3', title: 'Create Nest App - Sub Task 3', todoItemId: '1' },
-            min: { description: null, id: '1', title: 'Create Nest App - Sub Task 1', todoItemId: '1' },
-            sum: { id: 6 },
-          });
+          const agg: AggregateResponse<TagDTO>[] = body.data.todoItem.subTasksAggregate;
+          expect(agg).toEqual([
+            {
+              avg: { id: 2 },
+              count: { completed: 3, description: 0, id: 3, title: 3, todoItemId: 3 },
+              max: { description: null, id: '3', title: 'Create Nest App - Sub Task 3', todoItemId: '1' },
+              min: { description: null, id: '1', title: 'Create Nest App - Sub Task 1', todoItemId: '1' },
+              sum: { id: 6 },
+            },
+          ]);
         }));
 
     it(`should return tags as a connection`, () =>
@@ -196,14 +198,16 @@ describe('TodoItemResolver (typeorm - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const agg: AggregateResponse<TagDTO> = body.data.todoItem.tagsAggregate;
-          expect(agg).toEqual({
-            avg: { id: 1.5 },
-            count: { created: 2, id: 2, name: 2, updated: 2 },
-            max: { id: '2', name: 'Urgent' },
-            min: { id: '1', name: 'Home' },
-            sum: { id: 3 },
-          });
+          const agg: AggregateResponse<TagDTO>[] = body.data.todoItem.tagsAggregate;
+          expect(agg).toEqual([
+            {
+              avg: { id: 1.5 },
+              count: { created: 2, id: 2, name: 2, updated: 2 },
+              max: { id: '2', name: 'Urgent' },
+              min: { id: '1', name: 'Home' },
+              sum: { id: 3 },
+            },
+          ]);
         }));
   });
 
@@ -488,14 +492,55 @@ describe('TodoItemResolver (typeorm - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.todoItemAggregate;
-          expect(res).toEqual({
-            avg: { id: 3 },
-            count: { completed: 5, created: 5, description: 0, id: 5, title: 5, updated: 5 },
-            max: { description: null, id: '5', title: 'How to create item With Sub Tasks' },
-            min: { description: null, id: '1', title: 'Add Todo Item Resolver' },
-            sum: { id: 15 },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.todoItemAggregate;
+          expect(res).toEqual([
+            {
+              avg: { id: 3 },
+              count: { completed: 5, created: 5, description: 0, id: 5, title: 5, updated: 5 },
+              max: { description: null, id: '5', title: 'How to create item With Sub Tasks' },
+              min: { description: null, id: '1', title: 'Add Todo Item Resolver' },
+              sum: { id: 15 },
+            },
+          ]);
+        }));
+
+    it(`should return a aggregate response with groupBy`, () =>
+      request(app.getHttpServer())
+        .post('/graphql')
+        .set(AUTH_HEADER_NAME, config.auth.header)
+        .send({
+          operationName: null,
+          variables: {},
+          query: `{ 
+          todoItemAggregate {
+              groupBy {
+                completed
+              }
+              ${todoItemAggregateFields}
+            }
+        }`,
+        })
+        .expect(200)
+        .then(({ body }) => {
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.todoItemAggregate;
+          expect(res).toEqual([
+            {
+              groupBy: { completed: false },
+              avg: { id: 3.5 },
+              count: { completed: 4, created: 4, description: 0, id: 4, title: 4, updated: 4 },
+              max: { description: null, id: '5', title: 'How to create item With Sub Tasks' },
+              min: { description: null, id: '2', title: 'Add Todo Item Resolver' },
+              sum: { id: 14 },
+            },
+            {
+              groupBy: { completed: true },
+              avg: { id: 1 },
+              count: { completed: 1, created: 1, description: 0, id: 1, title: 1, updated: 1 },
+              max: { description: null, id: '1', title: 'Create Nest App' },
+              min: { description: null, id: '1', title: 'Create Nest App' },
+              sum: { id: 1 },
+            },
+          ]);
         }));
 
     it(`should allow filtering`, () =>
@@ -513,14 +558,16 @@ describe('TodoItemResolver (typeorm - e2e)', () => {
         })
         .expect(200)
         .then(({ body }) => {
-          const res: AggregateResponse<TodoItemDTO> = body.data.todoItemAggregate;
-          expect(res).toEqual({
-            count: { id: 4, title: 4, description: 0, completed: 4, created: 4, updated: 4 },
-            sum: { id: 14 },
-            avg: { id: 3.5 },
-            min: { id: '2', title: 'Add Todo Item Resolver', description: null },
-            max: { id: '5', title: 'How to create item With Sub Tasks', description: null },
-          });
+          const res: AggregateResponse<TodoItemDTO>[] = body.data.todoItemAggregate;
+          expect(res).toEqual([
+            {
+              count: { id: 4, title: 4, description: 0, completed: 4, created: 4, updated: 4 },
+              sum: { id: 14 },
+              avg: { id: 3.5 },
+              min: { id: '2', title: 'Add Todo Item Resolver', description: null },
+              max: { id: '5', title: 'How to create item With Sub Tasks', description: null },
+            },
+          ]);
         }));
   });
 

--- a/packages/core/__tests__/services/assembler-query.service.spec.ts
+++ b/packages/core/__tests__/services/assembler-query.service.spec.ts
@@ -178,7 +178,7 @@ describe('AssemblerQueryService', () => {
       const mockQueryService = mock<QueryService<TestEntity>>();
       const assemblerService = new AssemblerQueryService(new TestAssembler(), instance(mockQueryService));
       const aggQuery: AggregateQuery<TestDTO> = { count: ['foo'] };
-      const result: AggregateResponse<TestDTO> = { count: { foo: 1 } };
+      const result: AggregateResponse<TestDTO>[] = [{ count: { foo: 1 } }];
       when(
         mockQueryService.aggregateRelations(
           TestDTO,
@@ -233,10 +233,10 @@ describe('AssemblerQueryService', () => {
           objectContaining({ foo: { eq: 'bar' } }),
           aggQuery,
         ),
-      ).thenResolve(new Map<TestEntity, AggregateResponse<TestDTO>>());
+      ).thenResolve(new Map<TestEntity, AggregateResponse<TestDTO>[]>());
       return expect(
         assemblerService.aggregateRelations(TestDTO, 'test', [{ foo: 'bar' }], { foo: { eq: 'bar' } }, aggQuery),
-      ).resolves.toEqual(new Map([[dto, {}]]));
+      ).resolves.toEqual(new Map([[dto, []]]));
     });
   });
 

--- a/packages/core/__tests__/services/proxy-query.service.spec.ts
+++ b/packages/core/__tests__/services/proxy-query.service.spec.ts
@@ -77,7 +77,7 @@ describe('ProxyQueryService', () => {
   it('should proxy to the underlying service when calling aggregate', () => {
     const filter = {};
     const aggregate: AggregateQuery<TestType> = { count: ['foo'] };
-    const result = { count: { foo: 1 } };
+    const result = [{ count: { foo: 1 } }];
     when(mockQueryService.aggregate(filter, aggregate)).thenResolve(result);
     return expect(queryService.aggregate(filter, aggregate)).resolves.toBe(result);
   });
@@ -110,7 +110,7 @@ describe('ProxyQueryService', () => {
     const dto = new TestType();
     const filter = {};
     const aggQuery: AggregateQuery<TestType> = { count: ['foo'] };
-    const result = { count: { foo: 1 } };
+    const result = [{ count: { foo: 1 } }];
     when(mockQueryService.aggregateRelations(TestType, relationName, dto, filter, aggQuery)).thenResolve(result);
     return expect(queryService.aggregateRelations(TestType, relationName, dto, filter, aggQuery)).resolves.toBe(result);
   });
@@ -120,7 +120,7 @@ describe('ProxyQueryService', () => {
     const dtos = [new TestType()];
     const filter = {};
     const aggQuery: AggregateQuery<TestType> = { count: ['foo'] };
-    const result = new Map([[{ foo: 'bar' }, { count: { foo: 1 } }]]);
+    const result = new Map([[{ foo: 'bar' }, [{ count: { foo: 1 } }]]]);
     when(mockQueryService.aggregateRelations(TestType, relationName, dtos, filter, aggQuery)).thenResolve(result);
     return expect(queryService.aggregateRelations(TestType, relationName, dtos, filter, aggQuery)).resolves.toBe(
       result,

--- a/packages/core/__tests__/services/relation-query.service.spec.ts
+++ b/packages/core/__tests__/services/relation-query.service.spec.ts
@@ -128,7 +128,7 @@ describe('RelationQueryService', () => {
     it('should proxy to the underlying service when calling queryRelations with one dto', async () => {
       const relationName = 'test';
       const dto = new TestType();
-      const result = { count: { foo: 1 } };
+      const result = [{ count: { foo: 1 } }];
       const filter = {};
       const relationFilter = {};
       const relationAggregateQuery: AggregateQuery<TestType> = { count: ['foo'] };
@@ -143,7 +143,7 @@ describe('RelationQueryService', () => {
     it('should proxy to the underlying service when calling queryRelations with many dtos', async () => {
       const relationName = 'test';
       const dtos = [new TestType()];
-      const relationResults = { count: { foo: 1 } };
+      const relationResults = [{ count: { foo: 1 } }];
       const result = new Map([[dtos[0], relationResults]]);
       const filter = {};
       const relationFilter = {};
@@ -162,7 +162,7 @@ describe('RelationQueryService', () => {
       const dto = new TestType();
       const filter = {};
       const aggregateQuery: AggregateQuery<TestType> = { count: ['foo'] };
-      const result = { count: { foo: 1 } };
+      const result = [{ count: { foo: 1 } }];
       when(mockQueryService.aggregateRelations(TestType, relationName, dto, filter, aggregateQuery)).thenResolve(
         result,
       );
@@ -176,7 +176,7 @@ describe('RelationQueryService', () => {
       const dtos = [new TestType()];
       const filter = {};
       const aggregateQuery: AggregateQuery<TestType> = { count: ['foo'] };
-      const result = new Map([[dtos[0], { count: { foo: 1 } }]]);
+      const result = new Map([[dtos[0], [{ count: { foo: 1 } }]]]);
       when(mockQueryService.aggregateRelations(TestType, relationName, dtos, filter, aggregateQuery)).thenResolve(
         result,
       );

--- a/packages/core/src/interfaces/aggregate-query.interface.ts
+++ b/packages/core/src/interfaces/aggregate-query.interface.ts
@@ -4,4 +4,17 @@ export type AggregateQuery<DTO> = {
   avg?: (keyof DTO)[];
   max?: (keyof DTO)[];
   min?: (keyof DTO)[];
+  groupBy?: (keyof DTO)[];
 };
+
+// const j = `invoiceAgg(filter: {}){
+//   groupBy {
+//     currency
+//     created
+//   }
+//   max {
+//     amount
+//     date
+//  };
+// }`;
+//

--- a/packages/core/src/interfaces/aggregate-query.interface.ts
+++ b/packages/core/src/interfaces/aggregate-query.interface.ts
@@ -6,15 +6,3 @@ export type AggregateQuery<DTO> = {
   min?: (keyof DTO)[];
   groupBy?: (keyof DTO)[];
 };
-
-// const j = `invoiceAgg(filter: {}){
-//   groupBy {
-//     currency
-//     created
-//   }
-//   max {
-//     amount
-//     date
-//  };
-// }`;
-//

--- a/packages/core/src/interfaces/aggregate-response.interface.ts
+++ b/packages/core/src/interfaces/aggregate-response.interface.ts
@@ -12,4 +12,5 @@ export type AggregateResponse<DTO> = {
   avg?: NumberAggregate<DTO>;
   max?: TypeAggregate<DTO>;
   min?: TypeAggregate<DTO>;
+  groupBy?: Partial<DTO>;
 };

--- a/packages/core/src/services/assembler-query.service.ts
+++ b/packages/core/src/services/assembler-query.service.ts
@@ -71,12 +71,12 @@ export class AssemblerQueryService<DTO, Entity, C = DeepPartial<DTO>, CE = DeepP
     return this.assembler.convertAsyncToDTOs(this.queryService.query(this.assembler.convertQuery(query)));
   }
 
-  async aggregate(filter: Filter<DTO>, aggregate: AggregateQuery<DTO>): Promise<AggregateResponse<DTO>> {
+  async aggregate(filter: Filter<DTO>, aggregate: AggregateQuery<DTO>): Promise<AggregateResponse<DTO>[]> {
     const aggregateResponse = await this.queryService.aggregate(
       this.assembler.convertQuery({ filter }).filter || {},
       this.assembler.convertAggregateQuery(aggregate),
     );
-    return this.assembler.convertAggregateResponse(aggregateResponse);
+    return aggregateResponse.map((agg) => this.assembler.convertAggregateResponse(agg));
   }
 
   count(filter: Filter<DTO>): Promise<number> {
@@ -258,21 +258,21 @@ export class AssemblerQueryService<DTO, Entity, C = DeepPartial<DTO>, CE = DeepP
     dto: DTO,
     filter: Filter<Relation>,
     aggregate: AggregateQuery<Relation>,
-  ): Promise<AggregateResponse<Relation>>;
+  ): Promise<AggregateResponse<Relation>[]>;
   aggregateRelations<Relation>(
     RelationClass: Class<Relation>,
     relationName: string,
     dtos: DTO[],
     filter: Filter<Relation>,
     aggregate: AggregateQuery<Relation>,
-  ): Promise<Map<DTO, AggregateResponse<Relation>>>;
+  ): Promise<Map<DTO, AggregateResponse<Relation>[]>>;
   async aggregateRelations<Relation>(
     RelationClass: Class<Relation>,
     relationName: string,
     dto: DTO | DTO[],
     filter: Filter<Relation>,
     aggregate: AggregateQuery<Relation>,
-  ): Promise<AggregateResponse<Relation> | Map<DTO, AggregateResponse<Relation>>> {
+  ): Promise<AggregateResponse<Relation>[] | Map<DTO, AggregateResponse<Relation>[]>> {
     if (Array.isArray(dto)) {
       const entities = this.assembler.convertToEntities(dto);
       const relationMap = await this.queryService.aggregateRelations(
@@ -283,10 +283,10 @@ export class AssemblerQueryService<DTO, Entity, C = DeepPartial<DTO>, CE = DeepP
         aggregate,
       );
       return entities.reduce((map, e, index) => {
-        const entry = relationMap.get(e) ?? {};
+        const entry = relationMap.get(e) ?? [];
         map.set(dto[index], entry);
         return map;
-      }, new Map<DTO, AggregateResponse<Relation>>());
+      }, new Map<DTO, AggregateResponse<Relation>[]>());
     }
     return this.queryService.aggregateRelations(
       RelationClass,

--- a/packages/core/src/services/noop-query.service.ts
+++ b/packages/core/src/services/noop-query.service.ts
@@ -88,7 +88,7 @@ export class NoOpQueryService<DTO, C = DeepPartial<DTO>, U = DeepPartial<DTO>> i
     return Promise.reject(new NotImplementedException('query is not implemented'));
   }
 
-  aggregate(filter: Filter<DTO>, aggregate: AggregateQuery<DTO>): Promise<AggregateResponse<DTO>> {
+  aggregate(filter: Filter<DTO>, aggregate: AggregateQuery<DTO>): Promise<AggregateResponse<DTO>[]> {
     return Promise.reject(new NotImplementedException('aggregate is not implemented'));
   }
 
@@ -183,7 +183,7 @@ export class NoOpQueryService<DTO, C = DeepPartial<DTO>, U = DeepPartial<DTO>> i
     dto: DTO,
     filter: Filter<Relation>,
     aggregate: AggregateQuery<Relation>,
-  ): Promise<AggregateResponse<Relation>>;
+  ): Promise<AggregateResponse<Relation>[]>;
 
   aggregateRelations<Relation>(
     RelationClass: Class<Relation>,
@@ -191,7 +191,7 @@ export class NoOpQueryService<DTO, C = DeepPartial<DTO>, U = DeepPartial<DTO>> i
     dtos: DTO[],
     filter: Filter<Relation>,
     aggregate: AggregateQuery<Relation>,
-  ): Promise<Map<DTO, AggregateResponse<Relation>>>;
+  ): Promise<Map<DTO, AggregateResponse<Relation>[]>>;
 
   aggregateRelations<Relation>(
     RelationClass: Class<Relation>,
@@ -199,7 +199,7 @@ export class NoOpQueryService<DTO, C = DeepPartial<DTO>, U = DeepPartial<DTO>> i
     dto: DTO | DTO[],
     filter: Filter<Relation>,
     aggregate: AggregateQuery<Relation>,
-  ): Promise<AggregateResponse<Relation> | Map<DTO, AggregateResponse<Relation>>> {
+  ): Promise<AggregateResponse<Relation>[] | Map<DTO, AggregateResponse<Relation>[]>> {
     return Promise.reject(new NotImplementedException('aggregateRelations is not implemented'));
   }
 }

--- a/packages/core/src/services/proxy-query.service.ts
+++ b/packages/core/src/services/proxy-query.service.ts
@@ -188,7 +188,7 @@ export class ProxyQueryService<DTO, C = DeepPartial<DTO>, U = DeepPartial<DTO>> 
     return this.proxied.query(query);
   }
 
-  aggregate(filter: Filter<DTO>, query: AggregateQuery<DTO>): Promise<AggregateResponse<DTO>> {
+  aggregate(filter: Filter<DTO>, query: AggregateQuery<DTO>): Promise<AggregateResponse<DTO>[]> {
     return this.proxied.aggregate(filter, query);
   }
 
@@ -210,21 +210,21 @@ export class ProxyQueryService<DTO, C = DeepPartial<DTO>, U = DeepPartial<DTO>> 
     dto: DTO,
     filter: Filter<Relation>,
     aggregate: AggregateQuery<Relation>,
-  ): Promise<AggregateResponse<Relation>>;
+  ): Promise<AggregateResponse<Relation>[]>;
   aggregateRelations<Relation>(
     RelationClass: Class<Relation>,
     relationName: string,
     dtos: DTO[],
     filter: Filter<Relation>,
     aggregate: AggregateQuery<Relation>,
-  ): Promise<Map<DTO, AggregateResponse<Relation>>>;
+  ): Promise<Map<DTO, AggregateResponse<Relation>[]>>;
   async aggregateRelations<Relation>(
     RelationClass: Class<Relation>,
     relationName: string,
     dto: DTO | DTO[],
     filter: Filter<Relation>,
     aggregate: AggregateQuery<Relation>,
-  ): Promise<AggregateResponse<Relation> | Map<DTO, AggregateResponse<Relation>>> {
+  ): Promise<AggregateResponse<Relation>[] | Map<DTO, AggregateResponse<Relation>[]>> {
     if (Array.isArray(dto)) {
       return this.proxied.aggregateRelations(RelationClass, relationName, dto, filter, aggregate);
     }

--- a/packages/core/src/services/query.service.ts
+++ b/packages/core/src/services/query.service.ts
@@ -33,7 +33,7 @@ export interface QueryService<DTO, C = DeepPartial<DTO>, U = DeepPartial<DTO>> {
    * @param filter
    * @param aggregate
    */
-  aggregate(filter: Filter<DTO>, aggregate: AggregateQuery<DTO>): Promise<AggregateResponse<DTO>>;
+  aggregate(filter: Filter<DTO>, aggregate: AggregateQuery<DTO>): Promise<AggregateResponse<DTO>[]>;
 
   /**
    * Count the number of records that match the filter.
@@ -85,7 +85,7 @@ export interface QueryService<DTO, C = DeepPartial<DTO>, U = DeepPartial<DTO>> {
     dto: DTO,
     filter: Filter<Relation>,
     aggregate: AggregateQuery<Relation>,
-  ): Promise<AggregateResponse<Relation>>;
+  ): Promise<AggregateResponse<Relation>[]>;
 
   aggregateRelations<Relation>(
     RelationClass: Class<Relation>,
@@ -93,7 +93,7 @@ export interface QueryService<DTO, C = DeepPartial<DTO>, U = DeepPartial<DTO>> {
     dtos: DTO[],
     filter: Filter<Relation>,
     aggregate: AggregateQuery<Relation>,
-  ): Promise<Map<DTO, AggregateResponse<Relation>>>;
+  ): Promise<Map<DTO, AggregateResponse<Relation>[]>>;
 
   /**
    * Count the number of relations

--- a/packages/core/src/services/relation-query.service.ts
+++ b/packages/core/src/services/relation-query.service.ts
@@ -95,7 +95,7 @@ export class RelationQueryService<DTO, C = DeepPartial<DTO>, U = DeepPartial<DTO
     dto: DTO,
     filter: Filter<Relation>,
     aggregate: AggregateQuery<Relation>,
-  ): Promise<AggregateResponse<Relation>>;
+  ): Promise<AggregateResponse<Relation>[]>;
 
   async aggregateRelations<Relation>(
     RelationClass: Class<Relation>,
@@ -103,7 +103,7 @@ export class RelationQueryService<DTO, C = DeepPartial<DTO>, U = DeepPartial<DTO
     dtos: DTO[],
     filter: Filter<Relation>,
     aggregate: AggregateQuery<Relation>,
-  ): Promise<Map<DTO, AggregateResponse<Relation>>>;
+  ): Promise<Map<DTO, AggregateResponse<Relation>[]>>;
 
   async aggregateRelations<Relation>(
     RelationClass: Class<Relation>,
@@ -111,7 +111,7 @@ export class RelationQueryService<DTO, C = DeepPartial<DTO>, U = DeepPartial<DTO
     dto: DTO | DTO[],
     filter: Filter<Relation>,
     aggregate: AggregateQuery<Relation>,
-  ): Promise<AggregateResponse<Relation> | Map<DTO, AggregateResponse<Relation>>> {
+  ): Promise<AggregateResponse<Relation>[] | Map<DTO, AggregateResponse<Relation>[]>> {
     const serviceRelation = this.getRelation<Relation>(relationName);
     if (!serviceRelation) {
       if (Array.isArray(dto)) {
@@ -121,7 +121,7 @@ export class RelationQueryService<DTO, C = DeepPartial<DTO>, U = DeepPartial<DTO
     }
     const { query: qf, service } = serviceRelation;
     if (Array.isArray(dto)) {
-      const map = new Map<DTO, AggregateResponse<Relation>>();
+      const map = new Map<DTO, AggregateResponse<Relation>[]>();
       await Promise.all(
         dto.map(async (d) => {
           const relations = await service.aggregate(mergeQuery({ filter }, qf(d)).filter ?? {}, aggregate);

--- a/packages/query-graphql/__tests__/__fixtures__/aggregate-response-type-with-custom-name.graphql
+++ b/packages/query-graphql/__tests__/__fixtures__/aggregate-response-type-with-custom-name.graphql
@@ -1,3 +1,15 @@
+type FakeTypeAggregateGroupBy {
+  stringField: String
+  numberField: Float
+  boolField: Boolean
+  dateField: DateTime
+}
+
+"""
+A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
+"""
+scalar DateTime
+
 type FakeTypeCountAggregate {
   stringField: Int
   numberField: Int
@@ -19,14 +31,16 @@ type FakeTypeMinAggregate {
   dateField: DateTime
 }
 
-"""
-A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
-"""
-scalar DateTime
-
 type FakeTypeMaxAggregate {
   stringField: String
   numberField: Float
+  dateField: DateTime
+}
+
+type CustomPrefixAggregateGroupBy {
+  stringField: String
+  numberField: Float
+  boolField: Boolean
   dateField: DateTime
 }
 
@@ -58,6 +72,7 @@ type CustomPrefixMaxAggregate {
 }
 
 type CustomPrefixAggregateResponse {
+  groupBy: CustomPrefixAggregateGroupBy
   count: CustomPrefixCountAggregate
   sum: CustomPrefixSumAggregate
   avg: CustomPrefixAvgAggregate

--- a/packages/query-graphql/__tests__/__fixtures__/aggregate-response-type.graphql
+++ b/packages/query-graphql/__tests__/__fixtures__/aggregate-response-type.graphql
@@ -1,3 +1,15 @@
+type FakeTypeAggregateGroupBy {
+  stringField: String
+  numberField: Float
+  boolField: Boolean
+  dateField: DateTime
+}
+
+"""
+A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
+"""
+scalar DateTime
+
 type FakeTypeCountAggregate {
   stringField: Int
   numberField: Int
@@ -19,11 +31,6 @@ type FakeTypeMinAggregate {
   dateField: DateTime
 }
 
-"""
-A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
-"""
-scalar DateTime
-
 type FakeTypeMaxAggregate {
   stringField: String
   numberField: Float
@@ -31,6 +38,7 @@ type FakeTypeMaxAggregate {
 }
 
 type FakeTypeAggregateResponse {
+  groupBy: FakeTypeAggregateGroupBy
   count: FakeTypeCountAggregate
   sum: FakeTypeSumAggregate
   avg: FakeTypeAvgAggregate

--- a/packages/query-graphql/__tests__/loaders/aggregate-relations.loader.spec.ts
+++ b/packages/query-graphql/__tests__/loaders/aggregate-relations.loader.spec.ts
@@ -26,8 +26,8 @@ describe('AggregateRelationsLoader', () => {
       const filter = {};
       const aggregate: AggregateQuery<RelationDTO> = { count: ['id'] };
       const dtos = [{ id: 'dto-1' }, { id: 'dto-2' }];
-      const dto1Aggregate = { count: { id: 2 } };
-      const dto2Aggregate = { count: { id: 3 } };
+      const dto1Aggregate = [{ count: { id: 2 } }];
+      const dto2Aggregate = [{ count: { id: 3 } }];
       when(
         service.aggregateRelations(RelationDTO, 'relation', deepEqual(dtos), deepEqual(filter), deepEqual(aggregate)),
       ).thenResolve(
@@ -52,7 +52,7 @@ describe('AggregateRelationsLoader', () => {
       const filter = {};
       const aggregate: AggregateQuery<RelationDTO> = { count: ['id'] };
       const dtos = [{ id: 'dto-1' }, { id: 'dto-2' }];
-      const dto1Aggregate = { count: { id: 2 } };
+      const dto1Aggregate = [{ count: { id: 2 } }];
       when(
         service.aggregateRelations(RelationDTO, 'relation', deepEqual(dtos), deepEqual(filter), deepEqual(aggregate)),
       ).thenResolve(new Map([[dtos[0], dto1Aggregate]]));
@@ -73,10 +73,10 @@ describe('AggregateRelationsLoader', () => {
       const filter2 = {};
       const aggregate: AggregateQuery<RelationDTO> = { count: ['id'] };
       const dtos = [{ id: 'dto-1' }, { id: 'dto-2' }, { id: 'dto-3' }, { id: 'dto-4' }];
-      const dto1Aggregate = { count: { id: 2 } };
-      const dto2Aggregate = { count: { id: 3 } };
-      const dto3Aggregate = { count: { id: 4 } };
-      const dto4Aggregate = { count: { id: 5 } };
+      const dto1Aggregate = [{ count: { id: 2 } }];
+      const dto2Aggregate = [{ count: { id: 3 } }];
+      const dto3Aggregate = [{ count: { id: 4 } }];
+      const dto4Aggregate = [{ count: { id: 5 } }];
       when(
         service.aggregateRelations(
           RelationDTO,
@@ -124,10 +124,10 @@ describe('AggregateRelationsLoader', () => {
       const aggregate1: AggregateQuery<RelationDTO> = { count: ['id'] };
       const aggregate2: AggregateQuery<RelationDTO> = { sum: ['id'] };
       const dtos = [{ id: 'dto-1' }, { id: 'dto-2' }, { id: 'dto-3' }, { id: 'dto-4' }];
-      const dto1Aggregate = { count: { id: 2 } };
-      const dto2Aggregate = { sum: { id: 3 } };
-      const dto3Aggregate = { count: { id: 4 } };
-      const dto4Aggregate = { sum: { id: 5 } };
+      const dto1Aggregate = [{ count: { id: 2 } }];
+      const dto2Aggregate = [{ sum: { id: 3 } }];
+      const dto3Aggregate = [{ count: { id: 4 } }];
+      const dto4Aggregate = [{ sum: { id: 5 } }];
       when(
         service.aggregateRelations(
           RelationDTO,

--- a/packages/query-graphql/__tests__/resolvers/__fixtures__/aggregate/aggregate-disabled.resolver.graphql
+++ b/packages/query-graphql/__tests__/resolvers/__fixtures__/aggregate/aggregate-disabled.resolver.graphql
@@ -3,6 +3,11 @@ type TestResolverDTO {
   stringField: String!
 }
 
+type TestResolverDTOAggregateGroupBy {
+  id: ID
+  stringField: String
+}
+
 type TestResolverDTOCountAggregate {
   id: Int
   stringField: Int

--- a/packages/query-graphql/__tests__/resolvers/__fixtures__/aggregate/aggregate.resolver.graphql
+++ b/packages/query-graphql/__tests__/resolvers/__fixtures__/aggregate/aggregate.resolver.graphql
@@ -3,6 +3,11 @@ type TestResolverDTO {
   stringField: String!
 }
 
+type TestResolverDTOAggregateGroupBy {
+  id: ID
+  stringField: String
+}
+
 type TestResolverDTOCountAggregate {
   id: Int
   stringField: Int
@@ -19,6 +24,7 @@ type TestResolverDTOMaxAggregate {
 }
 
 type TestResolverDTOAggregateResponse {
+  groupBy: TestResolverDTOAggregateGroupBy
   count: TestResolverDTOCountAggregate
   min: TestResolverDTOMinAggregate
   max: TestResolverDTOMaxAggregate
@@ -28,7 +34,7 @@ type Query {
   testResolverDTOAggregate(
     """Filter to find records to aggregate on"""
     filter: TestResolverDTOAggregateFilter
-  ): TestResolverDTOAggregateResponse!
+  ): [TestResolverDTOAggregateResponse!]!
   test: TestResolverDTO!
 }
 

--- a/packages/query-graphql/__tests__/resolvers/aggregate.resolver.spec.ts
+++ b/packages/query-graphql/__tests__/resolvers/aggregate.resolver.spec.ts
@@ -44,9 +44,11 @@ describe('AggregateResolver', () => {
         },
       };
       const aggregateQuery: AggregateQuery<TestResolverDTO> = { count: ['id'] };
-      const output: AggregateResponse<TestResolverDTO> = {
-        count: { id: 10 },
-      };
+      const output: AggregateResponse<TestResolverDTO>[] = [
+        {
+          count: { id: 10 },
+        },
+      ];
       when(mockService.aggregate(objectContaining(input.filter!), deepEqual(aggregateQuery))).thenResolve(output);
       const result = await resolver.aggregate(input, aggregateQuery);
       return expect(result).toEqual(output);

--- a/packages/query-graphql/__tests__/resolvers/relations/__fixtures__/aggregate/aggregate-relation-custom-name.resolver.graphql
+++ b/packages/query-graphql/__tests__/resolvers/relations/__fixtures__/aggregate/aggregate-relation-custom-name.resolver.graphql
@@ -4,7 +4,7 @@ type TestResolverDTO {
   testsAggregate(
     """Filter to find records to aggregate on"""
     filter: TestRelationDTOAggregateFilter
-  ): TestResolverDTOTestsAggregateResponse!
+  ): [TestResolverDTOTestsAggregateResponse!]!
 }
 
 input TestRelationDTOAggregateFilter {
@@ -48,6 +48,11 @@ input StringFieldComparison {
   notIn: [String!]
 }
 
+type TestResolverDTORelationsAggregateGroupBy {
+  id: ID
+  testResolverId: String
+}
+
 type TestResolverDTORelationsCountAggregate {
   id: Int
   testResolverId: Int
@@ -59,6 +64,11 @@ type TestResolverDTORelationsMinAggregate {
 }
 
 type TestResolverDTORelationsMaxAggregate {
+  id: ID
+  testResolverId: String
+}
+
+type TestResolverDTOTestsAggregateGroupBy {
   id: ID
   testResolverId: String
 }
@@ -79,6 +89,7 @@ type TestResolverDTOTestsMaxAggregate {
 }
 
 type TestResolverDTOTestsAggregateResponse {
+  groupBy: TestResolverDTOTestsAggregateGroupBy
   count: TestResolverDTOTestsCountAggregate
   min: TestResolverDTOTestsMinAggregate
   max: TestResolverDTOTestsMaxAggregate

--- a/packages/query-graphql/__tests__/resolvers/relations/__fixtures__/aggregate/aggregate-relation-disabled.resolver.graphql
+++ b/packages/query-graphql/__tests__/resolvers/relations/__fixtures__/aggregate/aggregate-relation-disabled.resolver.graphql
@@ -3,6 +3,11 @@ type TestResolverDTO {
   stringField: String!
 }
 
+type TestResolverDTORelationsAggregateGroupBy {
+  id: ID
+  testResolverId: String
+}
+
 type TestResolverDTORelationsCountAggregate {
   id: Int
   testResolverId: Int
@@ -14,6 +19,11 @@ type TestResolverDTORelationsMinAggregate {
 }
 
 type TestResolverDTORelationsMaxAggregate {
+  id: ID
+  testResolverId: String
+}
+
+type TestResolverDTOTestsAggregateGroupBy {
   id: ID
   testResolverId: String
 }

--- a/packages/query-graphql/__tests__/resolvers/relations/__fixtures__/aggregate/aggregate-relation.resolver.graphql
+++ b/packages/query-graphql/__tests__/resolvers/relations/__fixtures__/aggregate/aggregate-relation.resolver.graphql
@@ -4,7 +4,7 @@ type TestResolverDTO {
   relationsAggregate(
     """Filter to find records to aggregate on"""
     filter: TestRelationDTOAggregateFilter
-  ): TestResolverDTORelationsAggregateResponse!
+  ): [TestResolverDTORelationsAggregateResponse!]!
 }
 
 input TestRelationDTOAggregateFilter {
@@ -48,6 +48,11 @@ input StringFieldComparison {
   notIn: [String!]
 }
 
+type TestResolverDTORelationsAggregateGroupBy {
+  id: ID
+  testResolverId: String
+}
+
 type TestResolverDTORelationsCountAggregate {
   id: Int
   testResolverId: Int
@@ -64,6 +69,7 @@ type TestResolverDTORelationsMaxAggregate {
 }
 
 type TestResolverDTORelationsAggregateResponse {
+  groupBy: TestResolverDTORelationsAggregateGroupBy
   count: TestResolverDTORelationsCountAggregate
   min: TestResolverDTORelationsMinAggregate
   max: TestResolverDTORelationsMaxAggregate

--- a/packages/query-graphql/__tests__/resolvers/relations/aggregate-relation.resolver.spec.ts
+++ b/packages/query-graphql/__tests__/resolvers/relations/aggregate-relation.resolver.spec.ts
@@ -68,10 +68,12 @@ describe('AggregateRelationsResolver', () => {
           count: ['id'],
           sum: ['testResolverId'],
         };
-        const output: AggregateResponse<TestRelationDTO> = {
-          count: { id: 10 },
-          sum: { testResolverId: 100 },
-        };
+        const output: AggregateResponse<TestRelationDTO>[] = [
+          {
+            count: { id: 10 },
+            sum: { testResolverId: 100 },
+          },
+        ];
         when(
           mockService.aggregateRelations(
             TestRelationDTO,

--- a/packages/query-graphql/src/decorators/aggregate-query-param.decorator.ts
+++ b/packages/query-graphql/src/decorators/aggregate-query-param.decorator.ts
@@ -5,7 +5,7 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import graphqlFields from 'graphql-fields';
 
 const EXCLUDED_FIELDS = ['__typename'];
-const QUERY_OPERATORS: (keyof AggregateQuery<unknown>)[] = ['count', 'avg', 'sum', 'min', 'max'];
+const QUERY_OPERATORS: (keyof AggregateQuery<unknown>)[] = ['groupBy', 'count', 'avg', 'sum', 'min', 'max'];
 export const AggregateQueryParam = createParamDecorator(<DTO>(data: unknown, ctx: ExecutionContext) => {
   const info = GqlExecutionContext.create(ctx).getInfo<GraphQLResolveInfo>();
   const fields = graphqlFields(info, {}, { excludedFields: EXCLUDED_FIELDS }) as Record<

--- a/packages/query-graphql/src/resolvers/aggregate.resolver.ts
+++ b/packages/query-graphql/src/resolvers/aggregate.resolver.ts
@@ -18,7 +18,7 @@ export interface AggregateResolver<DTO, QS extends QueryService<DTO, unknown, un
     filter: AggregateArgsType<DTO>,
     aggregateQuery: AggregateQuery<DTO>,
     authFilter?: Filter<DTO>,
-  ): Promise<AggregateResponse<DTO>>;
+  ): Promise<AggregateResponse<DTO>[]>;
 }
 
 /**
@@ -41,7 +41,7 @@ export const Aggregateable = <DTO, QS extends QueryService<DTO, unknown, unknown
     @SkipIf(
       () => !opts || !opts.enabled,
       ResolverQuery(
-        () => AR,
+        () => [AR],
         { name: queryName },
         commonResolverOpts,
         { interceptors: [AuthorizerInterceptor(DTOClass)] },
@@ -52,7 +52,7 @@ export const Aggregateable = <DTO, QS extends QueryService<DTO, unknown, unknown
       @Args() args: AA,
       @AggregateQueryParam() query: AggregateQuery<DTO>,
       @AuthorizerFilter() authFilter?: Filter<DTO>,
-    ): Promise<AggregateResponse<DTO>> {
+    ): Promise<AggregateResponse<DTO>[]> {
       const qa = await transformAndValidate(AA, args);
       return this.service.aggregate(mergeFilter(qa.filter || {}, authFilter ?? {}), query);
     }

--- a/packages/query-graphql/src/resolvers/relations/aggregate-relations.resolver.ts
+++ b/packages/query-graphql/src/resolvers/relations/aggregate-relations.resolver.ts
@@ -45,7 +45,7 @@ const AggregateRelationMixin = <DTO, Relation>(DTOClass: Class<DTO>, relation: A
   const AR = AggregateResponseType(relationDTO, { prefix: `${dtoName}${pluralBaseName}` });
   @Resolver(() => DTOClass, { isAbstract: true })
   class AggregateMixin extends Base {
-    @ResolverField(`${pluralBaseNameLower}Aggregate`, () => AR, {}, commonResolverOpts, {
+    @ResolverField(`${pluralBaseNameLower}Aggregate`, () => [AR], {}, commonResolverOpts, {
       interceptors: [AuthorizerInterceptor(DTOClass)],
     })
     async [`aggregate${pluralBaseName}`](

--- a/packages/query-graphql/src/types/aggregate/aggregate-response.type.ts
+++ b/packages/query-graphql/src/types/aggregate/aggregate-response.type.ts
@@ -20,6 +20,17 @@ function NumberAggregatedType<DTO>(
   return Aggregated;
 }
 
+function AggregateGroupByType<DTO>(name: string, fields: FilterableFieldDescriptor[]): Class<TypeAggregate<DTO>> {
+  @ObjectType(name)
+  class Aggregated {}
+  fields.forEach(({ propertyName, target, returnTypeFunc }) => {
+    const rt = returnTypeFunc ? returnTypeFunc() : target;
+    Field(() => rt, { nullable: true })(Aggregated.prototype, propertyName);
+  });
+
+  return Aggregated;
+}
+
 function AggregatedType<DTO>(name: string, fields: FilterableFieldDescriptor[]): Class<TypeAggregate<DTO>> {
   @ObjectType(name)
   class Aggregated {}
@@ -49,6 +60,7 @@ export function AggregateResponseType<DTO>(
     }
     const numberFields = fields.filter(({ target }) => target === Number);
     const minMaxFields = fields.filter(({ target }) => target !== Boolean);
+    const GroupType = AggregateGroupByType(`${prefix}AggregateGroupBy`, fields);
     const CountType = NumberAggregatedType(`${prefix}CountAggregate`, fields, Int);
     const SumType = NumberAggregatedType(`${prefix}SumAggregate`, numberFields, Float);
     const AvgType = NumberAggregatedType(`${prefix}AvgAggregate`, numberFields, Float);
@@ -57,6 +69,9 @@ export function AggregateResponseType<DTO>(
 
     @ObjectType(aggName)
     class AggResponse {
+      @Field(() => GroupType, { nullable: true })
+      groupBy?: Partial<DTO>;
+
       @Field(() => CountType, { nullable: true })
       count?: NumberAggregate<DTO>;
 

--- a/packages/query-mongoose/__tests__/query/aggregate.builder.spec.ts
+++ b/packages/query-mongoose/__tests__/query/aggregate.builder.spec.ts
@@ -1,70 +1,72 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { AggregateQuery } from '@nestjs-query/core';
 import { TestEntity } from '../__fixtures__/test.entity';
-import { AggregateBuilder, MongooseAggregate } from '../../src/query';
+import { AggregateBuilder } from '../../src/query';
 
 describe('AggregateBuilder', (): void => {
   const createAggregateBuilder = () => new AggregateBuilder<TestEntity>();
-
-  const assertQuery = (agg: AggregateQuery<TestEntity>, expected: MongooseAggregate): void => {
-    const actual = createAggregateBuilder().build(agg);
-    expect(actual).toEqual(expected);
-  };
 
   it('should throw an error if no selects are generated', (): void => {
     expect(() => createAggregateBuilder().build({})).toThrow('No aggregate fields found.');
   });
 
-  it('or multiple operators for a single field together', (): void => {
-    assertQuery(
-      {
-        count: ['id', 'stringType'],
-        avg: ['numberType'],
-        sum: ['numberType'],
-        max: ['stringType', 'dateType', 'numberType'],
-        min: ['stringType', 'dateType', 'numberType'],
+  it('should create an aggregate query', (): void => {
+    const agg: AggregateQuery<TestEntity> = {
+      count: ['id', 'stringType'],
+      avg: ['numberType'],
+      sum: ['numberType'],
+      max: ['stringType', 'dateType', 'numberType'],
+      min: ['stringType', 'dateType', 'numberType'],
+    };
+    expect(createAggregateBuilder().build(agg)).toEqual({
+      _id: null,
+      avg_numberType: { $avg: '$numberType' },
+      count_id: { $sum: { $cond: { else: 1, if: { $in: [{ $type: '$_id' }, ['missing', 'null']] }, then: 0 } } },
+      count_stringType: {
+        $sum: { $cond: { else: 1, if: { $in: [{ $type: '$stringType' }, ['missing', 'null']] }, then: 0 } },
       },
-      {
-        avg_numberType: { $avg: '$numberType' },
-        count_id: { $sum: { $cond: { else: 1, if: { $in: [{ $type: '$_id' }, ['missing', 'null']] }, then: 0 } } },
-        count_stringType: {
-          $sum: { $cond: { else: 1, if: { $in: [{ $type: '$stringType' }, ['missing', 'null']] }, then: 0 } },
-        },
-        max_dateType: { $max: '$dateType' },
-        max_numberType: { $max: '$numberType' },
-        max_stringType: { $max: '$stringType' },
-        min_dateType: { $min: '$dateType' },
-        min_numberType: { $min: '$numberType' },
-        min_stringType: { $min: '$stringType' },
-        sum_numberType: { $sum: '$numberType' },
-      },
-    );
+      max_dateType: { $max: '$dateType' },
+      max_numberType: { $max: '$numberType' },
+      max_stringType: { $max: '$stringType' },
+      min_dateType: { $min: '$dateType' },
+      min_numberType: { $min: '$numberType' },
+      min_stringType: { $min: '$stringType' },
+      sum_numberType: { $sum: '$numberType' },
+    });
   });
 
   describe('.convertToAggregateResponse', () => {
     it('should convert a flat response into an Aggregtate response', () => {
-      const dbResult = {
-        count_id: 10,
-        sum_numberType: 55,
-        avg_numberType: 5,
-        max_stringType: 'z',
-        max_numberType: 10,
-        min_stringType: 'a',
-        min_numberType: 1,
-      };
-      expect(AggregateBuilder.convertToAggregateResponse<TestEntity>(dbResult)).toEqual({
-        count: { id: 10 },
-        sum: { numberType: 55 },
-        avg: { numberType: 5 },
-        max: { stringType: 'z', numberType: 10 },
-        min: { stringType: 'a', numberType: 1 },
-      });
+      const dbResult = [
+        {
+          _id: { group_by_stringType: 'z' },
+          count_id: 10,
+          sum_numberType: 55,
+          avg_numberType: 5,
+          max_stringType: 'z',
+          max_numberType: 10,
+          min_stringType: 'a',
+          min_numberType: 1,
+        },
+      ];
+      expect(AggregateBuilder.convertToAggregateResponse<TestEntity>(dbResult)).toEqual([
+        {
+          groupBy: { stringType: 'z' },
+          count: { id: 10 },
+          sum: { numberType: 55 },
+          avg: { numberType: 5 },
+          max: { stringType: 'z', numberType: 10 },
+          min: { stringType: 'a', numberType: 1 },
+        },
+      ]);
     });
 
     it('should throw an error if a column is not expected', () => {
-      const dbResult = {
-        COUNTtestEntityPk: 10,
-      };
+      const dbResult = [
+        {
+          COUNTtestEntityPk: 10,
+        },
+      ];
       expect(() => AggregateBuilder.convertToAggregateResponse<TestEntity>(dbResult)).toThrow(
         'Unknown aggregate column encountered.',
       );

--- a/packages/query-mongoose/__tests__/services/mongoose-query.service.spec.ts
+++ b/packages/query-mongoose/__tests__/services/mongoose-query.service.spec.ts
@@ -240,32 +240,6 @@ describe('MongooseQueryService', () => {
       return expect(queryResult).toEqual([
         {
           groupBy: {
-            boolType: true,
-          },
-          avg: {
-            numberType: 6,
-          },
-          count: {
-            id: 5,
-          },
-          max: {
-            dateType: TEST_ENTITIES[9].dateType,
-            numberType: 10,
-            stringType: 'foo8',
-            id: expect.any(ObjectId),
-          },
-          min: {
-            dateType: TEST_ENTITIES[1].dateType,
-            numberType: 2,
-            stringType: 'foo10',
-            id: expect.any(ObjectId),
-          },
-          sum: {
-            numberType: 30,
-          },
-        },
-        {
-          groupBy: {
             boolType: false,
           },
           avg: {
@@ -288,6 +262,32 @@ describe('MongooseQueryService', () => {
           },
           sum: {
             numberType: 25,
+          },
+        },
+        {
+          groupBy: {
+            boolType: true,
+          },
+          avg: {
+            numberType: 6,
+          },
+          count: {
+            id: 5,
+          },
+          max: {
+            dateType: TEST_ENTITIES[9].dateType,
+            numberType: 10,
+            stringType: 'foo8',
+            id: expect.any(ObjectId),
+          },
+          min: {
+            dateType: TEST_ENTITIES[1].dateType,
+            numberType: 2,
+            stringType: 'foo10',
+            id: expect.any(ObjectId),
+          },
+          sum: {
+            numberType: 30,
           },
         },
       ]);

--- a/packages/query-mongoose/__tests__/services/mongoose-query.service.spec.ts
+++ b/packages/query-mongoose/__tests__/services/mongoose-query.service.spec.ts
@@ -197,29 +197,100 @@ describe('MongooseQueryService', () => {
           min: ['id', 'dateType', 'numberType', 'stringType'],
         },
       );
-      return expect(queryResult).toEqual({
-        avg: {
-          numberType: 5.5,
+      return expect(queryResult).toEqual([
+        {
+          avg: {
+            numberType: 5.5,
+          },
+          count: {
+            id: 10,
+          },
+          max: {
+            dateType: TEST_ENTITIES[9].dateType,
+            numberType: 10,
+            stringType: 'foo9',
+            id: expect.any(ObjectId),
+          },
+          min: {
+            dateType: TEST_ENTITIES[0].dateType,
+            numberType: 1,
+            stringType: 'foo1',
+            id: expect.any(ObjectId),
+          },
+          sum: {
+            numberType: 55,
+          },
         },
-        count: {
-          id: 10,
+      ]);
+    });
+
+    it('allow aggregates with groupBy', async () => {
+      const queryService = moduleRef.get(TestEntityService);
+      const queryResult = await queryService.aggregate(
+        {},
+        {
+          groupBy: ['boolType'],
+          count: ['id'],
+          avg: ['numberType'],
+          sum: ['numberType'],
+          max: ['id', 'dateType', 'numberType', 'stringType'],
+          min: ['id', 'dateType', 'numberType', 'stringType'],
         },
-        max: {
-          dateType: TEST_ENTITIES[9].dateType,
-          numberType: 10,
-          stringType: 'foo9',
-          id: expect.any(ObjectId),
+      );
+      return expect(queryResult).toEqual([
+        {
+          groupBy: {
+            boolType: true,
+          },
+          avg: {
+            numberType: 6,
+          },
+          count: {
+            id: 5,
+          },
+          max: {
+            dateType: TEST_ENTITIES[9].dateType,
+            numberType: 10,
+            stringType: 'foo8',
+            id: expect.any(ObjectId),
+          },
+          min: {
+            dateType: TEST_ENTITIES[1].dateType,
+            numberType: 2,
+            stringType: 'foo10',
+            id: expect.any(ObjectId),
+          },
+          sum: {
+            numberType: 30,
+          },
         },
-        min: {
-          dateType: TEST_ENTITIES[0].dateType,
-          numberType: 1,
-          stringType: 'foo1',
-          id: expect.any(ObjectId),
+        {
+          groupBy: {
+            boolType: false,
+          },
+          avg: {
+            numberType: 5,
+          },
+          count: {
+            id: 5,
+          },
+          max: {
+            dateType: TEST_ENTITIES[8].dateType,
+            numberType: 9,
+            stringType: 'foo9',
+            id: expect.any(ObjectId),
+          },
+          min: {
+            dateType: TEST_ENTITIES[0].dateType,
+            numberType: 1,
+            stringType: 'foo1',
+            id: expect.any(ObjectId),
+          },
+          sum: {
+            numberType: 25,
+          },
         },
-        sum: {
-          numberType: 55,
-        },
-      });
+      ]);
     });
 
     it('call select with the aggregate columns and return the result with a filter', async () => {
@@ -234,29 +305,31 @@ describe('MongooseQueryService', () => {
           min: ['id', 'dateType', 'numberType', 'stringType'],
         },
       );
-      return expect(queryResult).toEqual({
-        avg: {
-          numberType: 2,
+      return expect(queryResult).toEqual([
+        {
+          avg: {
+            numberType: 2,
+          },
+          count: {
+            id: 3,
+          },
+          max: {
+            dateType: TEST_ENTITIES[2].dateType,
+            numberType: 3,
+            stringType: 'foo3',
+            id: expect.any(ObjectId),
+          },
+          min: {
+            dateType: TEST_ENTITIES[0].dateType,
+            numberType: 1,
+            stringType: 'foo1',
+            id: expect.any(ObjectId),
+          },
+          sum: {
+            numberType: 6,
+          },
         },
-        count: {
-          id: 3,
-        },
-        max: {
-          dateType: TEST_ENTITIES[2].dateType,
-          numberType: 3,
-          stringType: 'foo3',
-          id: expect.any(ObjectId),
-        },
-        min: {
-          dateType: TEST_ENTITIES[0].dateType,
-          numberType: 1,
-          stringType: 'foo1',
-          id: expect.any(ObjectId),
-        },
-        sum: {
-          numberType: 6,
-        },
-      });
+      ]);
     });
   });
 
@@ -773,7 +846,7 @@ describe('MongooseQueryService', () => {
 
   describe('#aggregateRelations', () => {
     describe('with one entity', () => {
-      it('call select and return the result', async () => {
+      it('should return an aggregate', async () => {
         const queryService = moduleRef.get(TestEntityService);
         const aggResult = await queryService.aggregateRelations(
           TestReference,
@@ -782,11 +855,32 @@ describe('MongooseQueryService', () => {
           { referenceName: { isNot: null } },
           { count: ['id'] },
         );
-        return expect(aggResult).toEqual({
-          count: {
-            id: 3,
+        return expect(aggResult).toEqual([
+          {
+            count: {
+              id: 3,
+            },
           },
-        });
+        ]);
+      });
+
+      it('should support groupBy when aggregating relations', async () => {
+        const queryService = moduleRef.get(TestEntityService);
+        const aggResult = await queryService.aggregateRelations(
+          TestReference,
+          'testReferences',
+          TEST_ENTITIES[0],
+          { referenceName: { isNot: null } },
+          { groupBy: ['testEntity'], count: ['id'] },
+        );
+        return expect(aggResult).toEqual([
+          {
+            groupBy: { testEntity: TEST_ENTITIES[0]._id },
+            count: {
+              id: 3,
+            },
+          },
+        ]);
       });
     });
 
@@ -800,16 +894,18 @@ describe('MongooseQueryService', () => {
           { referenceName: { isNot: null } },
           { count: ['id'] },
         );
-        return expect(aggResult).toEqual({
-          count: {
-            id: 3,
+        return expect(aggResult).toEqual([
+          {
+            count: {
+              id: 3,
+            },
           },
-        });
+        ]);
       });
     });
 
     describe('with multiple entities', () => {
-      it('call select and return the result', async () => {
+      it('return a relation aggregate for each entity', async () => {
         const entities = TEST_ENTITIES.slice(0, 3);
         const queryService = moduleRef.get(TestEntityService);
         const queryResult = await queryService.aggregateRelations(
@@ -829,63 +925,161 @@ describe('MongooseQueryService', () => {
           new Map([
             [
               entities[0],
-              {
-                count: {
-                  referenceName: 3,
-                  testEntity: 3,
-                  id: 3,
+              [
+                {
+                  count: {
+                    referenceName: 3,
+                    testEntity: 3,
+                    id: 3,
+                  },
+                  max: {
+                    referenceName: TEST_REFERENCES[2].referenceName,
+                    testEntity: entities[0]._id,
+                    id: expect.any(ObjectId),
+                  },
+                  min: {
+                    referenceName: TEST_REFERENCES[0].referenceName,
+                    testEntity: entities[0]._id,
+                    id: expect.any(ObjectId),
+                  },
                 },
-                max: {
-                  referenceName: TEST_REFERENCES[2].referenceName,
-                  testEntity: entities[0]._id,
-                  id: expect.any(ObjectId),
-                },
-                min: {
-                  referenceName: TEST_REFERENCES[0].referenceName,
-                  testEntity: entities[0]._id,
-                  id: expect.any(ObjectId),
-                },
-              },
+              ],
             ],
             [
               entities[1],
-              {
-                count: {
-                  referenceName: 3,
-                  testEntity: 3,
-                  id: 3,
+              [
+                {
+                  count: {
+                    referenceName: 3,
+                    testEntity: 3,
+                    id: 3,
+                  },
+                  max: {
+                    referenceName: TEST_REFERENCES[5].referenceName,
+                    testEntity: entities[1]._id,
+                    id: expect.any(ObjectId),
+                  },
+                  min: {
+                    referenceName: TEST_REFERENCES[3].referenceName,
+                    testEntity: entities[1]._id,
+                    id: expect.any(ObjectId),
+                  },
                 },
-                max: {
-                  referenceName: TEST_REFERENCES[5].referenceName,
-                  testEntity: entities[1]._id,
-                  id: expect.any(ObjectId),
-                },
-                min: {
-                  referenceName: TEST_REFERENCES[3].referenceName,
-                  testEntity: entities[1]._id,
-                  id: expect.any(ObjectId),
-                },
-              },
+              ],
             ],
             [
               entities[2],
-              {
-                count: {
-                  referenceName: 3,
-                  testEntity: 3,
-                  id: 3,
+              [
+                {
+                  count: {
+                    referenceName: 3,
+                    testEntity: 3,
+                    id: 3,
+                  },
+                  max: {
+                    referenceName: TEST_REFERENCES[8].referenceName,
+                    testEntity: entities[2]._id,
+                    id: expect.any(ObjectId),
+                  },
+                  min: {
+                    referenceName: TEST_REFERENCES[6].referenceName,
+                    testEntity: entities[2]._id,
+                    id: expect.any(ObjectId),
+                  },
                 },
-                max: {
-                  referenceName: TEST_REFERENCES[8].referenceName,
-                  testEntity: entities[2]._id,
-                  id: expect.any(ObjectId),
+              ],
+            ],
+          ]),
+        );
+      });
+
+      it('aggregate and group for each entities relation', async () => {
+        const entities = TEST_ENTITIES.slice(0, 3);
+        const queryService = moduleRef.get(TestEntityService);
+        const queryResult = await queryService.aggregateRelations(
+          TestReference,
+          'testReferences',
+          entities,
+          { referenceName: { isNot: null } },
+          {
+            groupBy: ['testEntity'],
+            count: ['id', 'referenceName', 'testEntity'],
+            min: ['id', 'referenceName', 'testEntity'],
+            max: ['id', 'referenceName', 'testEntity'],
+          },
+        );
+
+        expect(queryResult.size).toBe(3);
+        expect(queryResult).toEqual(
+          new Map([
+            [
+              entities[0],
+              [
+                {
+                  groupBy: { testEntity: entities[0]._id },
+                  count: {
+                    referenceName: 3,
+                    testEntity: 3,
+                    id: 3,
+                  },
+                  max: {
+                    referenceName: TEST_REFERENCES[2].referenceName,
+                    testEntity: entities[0]._id,
+                    id: expect.any(ObjectId),
+                  },
+                  min: {
+                    referenceName: TEST_REFERENCES[0].referenceName,
+                    testEntity: entities[0]._id,
+                    id: expect.any(ObjectId),
+                  },
                 },
-                min: {
-                  referenceName: TEST_REFERENCES[6].referenceName,
-                  testEntity: entities[2]._id,
-                  id: expect.any(ObjectId),
+              ],
+            ],
+            [
+              entities[1],
+              [
+                {
+                  groupBy: { testEntity: entities[1]._id },
+                  count: {
+                    referenceName: 3,
+                    testEntity: 3,
+                    id: 3,
+                  },
+                  max: {
+                    referenceName: TEST_REFERENCES[5].referenceName,
+                    testEntity: entities[1]._id,
+                    id: expect.any(ObjectId),
+                  },
+                  min: {
+                    referenceName: TEST_REFERENCES[3].referenceName,
+                    testEntity: entities[1]._id,
+                    id: expect.any(ObjectId),
+                  },
                 },
-              },
+              ],
+            ],
+            [
+              entities[2],
+              [
+                {
+                  groupBy: { testEntity: entities[2]._id },
+                  count: {
+                    referenceName: 3,
+                    testEntity: 3,
+                    id: 3,
+                  },
+                  max: {
+                    referenceName: TEST_REFERENCES[8].referenceName,
+                    testEntity: entities[2]._id,
+                    id: expect.any(ObjectId),
+                  },
+                  min: {
+                    referenceName: TEST_REFERENCES[6].referenceName,
+                    testEntity: entities[2]._id,
+                    id: expect.any(ObjectId),
+                  },
+                },
+              ],
             ],
           ]),
         );
@@ -910,25 +1104,27 @@ describe('MongooseQueryService', () => {
           new Map([
             [
               entities[0],
-              {
-                count: {
-                  referenceName: 3,
-                  testEntity: 3,
-                  id: 3,
+              [
+                {
+                  count: {
+                    referenceName: 3,
+                    testEntity: 3,
+                    id: 3,
+                  },
+                  max: {
+                    referenceName: TEST_REFERENCES[2].referenceName,
+                    testEntity: entities[0]._id,
+                    id: expect.any(ObjectId),
+                  },
+                  min: {
+                    referenceName: TEST_REFERENCES[0].referenceName,
+                    testEntity: entities[0]._id,
+                    id: expect.any(ObjectId),
+                  },
                 },
-                max: {
-                  referenceName: TEST_REFERENCES[2].referenceName,
-                  testEntity: entities[0]._id,
-                  id: expect.any(ObjectId),
-                },
-                min: {
-                  referenceName: TEST_REFERENCES[0].referenceName,
-                  testEntity: entities[0]._id,
-                  id: expect.any(ObjectId),
-                },
-              },
+              ],
             ],
-            [entities[1], {}],
+            [entities[1], []],
           ]),
         );
       });

--- a/packages/query-mongoose/package.json
+++ b/packages/query-mongoose/package.json
@@ -21,7 +21,8 @@
     "@nestjs-query/core": "0.24.4",
     "lodash.escaperegexp": "^4.1.2",
     "lodash.merge": "^4.6.2",
-    "tslib": "^2.1.0"
+    "tslib": "^2.1.0",
+    "camel-case": "^4.1.2"
   },
   "peerDependencies": {
     "@nestjs/common": "^7.0.0",

--- a/packages/query-mongoose/src/query/aggregate.builder.ts
+++ b/packages/query-mongoose/src/query/aggregate.builder.ts
@@ -99,9 +99,21 @@ export class AggregateBuilder<Entity extends Document> {
       return null;
     }
     return fields.reduce((id: Record<string, string>, field) => {
-      const aggAlias = `group_by_${field as string}`;
+      const aggAlias = this.getGroupByAlias(field);
       const fieldAlias = `$${getSchemaKey(String(field))}`;
       return { ...id, [aggAlias]: fieldAlias };
     }, {});
+  }
+
+  getGroupBySelects(fields?: (keyof Entity)[]): string[] | undefined {
+    if (!fields) {
+      return undefined;
+    }
+    // append _id so it pulls the sort from the _id field
+    return (fields ?? []).map((f) => `_id.${this.getGroupByAlias(f)}`);
+  }
+
+  private getGroupByAlias(field: keyof Entity): string {
+    return `group_by_${field as string}`;
   }
 }

--- a/packages/query-mongoose/src/query/aggregate.builder.ts
+++ b/packages/query-mongoose/src/query/aggregate.builder.ts
@@ -1,6 +1,7 @@
 import { AggregateQuery, AggregateResponse } from '@nestjs-query/core';
 import { BadRequestException } from '@nestjs/common';
 import { Document } from 'mongoose';
+import { camelCase } from 'camel-case';
 import { getSchemaKey } from './helpers';
 
 enum AggregateFuncs {
@@ -10,14 +11,11 @@ enum AggregateFuncs {
   MAX = 'max',
   MIN = 'min',
 }
+type Aggregate = Record<string, Record<string, unknown>>;
+type Group = { _id: Record<string, string> | null };
+export type MongooseGroupAndAggregate = Aggregate & Group;
 
-export type MongooseAggregate = {
-  [k: string]: {
-    [o: string]: unknown;
-  };
-};
-
-const AGG_REGEXP = /(avg|sum|count|max|min)_(.*)/;
+const AGG_REGEXP = /(avg|sum|count|max|min|group_by)_(.*)/;
 
 /**
  * @internal
@@ -25,14 +23,24 @@ const AGG_REGEXP = /(avg|sum|count|max|min)_(.*)/;
  */
 export class AggregateBuilder<Entity extends Document> {
   // eslint-disable-next-line @typescript-eslint/no-shadow
-  static convertToAggregateResponse<Entity>({ _id, ...response }: Record<string, unknown>): AggregateResponse<Entity> {
+  static convertToAggregateResponse<Entity>(aggregates: Record<string, unknown>[]): AggregateResponse<Entity>[] {
+    return aggregates.map(({ _id, ...response }) => {
+      return { ...this.extractResponse(_id as Record<string, unknown>), ...this.extractResponse(response) };
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-shadow
+  private static extractResponse<Entity>(response?: Record<string, unknown>): AggregateResponse<Entity> {
+    if (!response) {
+      return {};
+    }
     return Object.keys(response).reduce((agg, resultField: string) => {
       const matchResult = AGG_REGEXP.exec(resultField);
       if (!matchResult) {
         throw new Error('Unknown aggregate column encountered.');
       }
       const [matchedFunc, matchedFieldName] = matchResult.slice(1);
-      const aggFunc = matchedFunc.toLowerCase() as keyof AggregateResponse<Entity>;
+      const aggFunc = camelCase(matchedFunc.toLowerCase()) as keyof AggregateResponse<Entity>;
       const fieldName = matchedFieldName as keyof Entity;
       const aggResult = agg[aggFunc] || {};
       return {
@@ -47,25 +55,25 @@ export class AggregateBuilder<Entity extends Document> {
    * Builds a aggregate SELECT clause from a aggregate.
    * @param aggregate - the aggregates to select.
    */
-  build(aggregate: AggregateQuery<Entity>): MongooseAggregate {
-    const query = {
+  build(aggregate: AggregateQuery<Entity>): MongooseGroupAndAggregate {
+    const aggSelect: Aggregate = {
       ...this.createAggSelect(AggregateFuncs.COUNT, aggregate.count),
       ...this.createAggSelect(AggregateFuncs.SUM, aggregate.sum),
       ...this.createAggSelect(AggregateFuncs.AVG, aggregate.avg),
       ...this.createAggSelect(AggregateFuncs.MAX, aggregate.max),
       ...this.createAggSelect(AggregateFuncs.MIN, aggregate.min),
     };
-    if (!Object.keys(query).length) {
+    if (!Object.keys(aggSelect).length) {
       throw new BadRequestException('No aggregate fields found.');
     }
-    return query;
+    return { ...aggSelect, _id: this.createGroupBySelect(aggregate.groupBy) } as MongooseGroupAndAggregate;
   }
 
-  private createAggSelect(func: AggregateFuncs, fields?: (keyof Entity)[]): MongooseAggregate {
+  private createAggSelect(func: AggregateFuncs, fields?: (keyof Entity)[]): Aggregate {
     if (!fields) {
       return {};
     }
-    return fields.reduce((agg: MongooseAggregate, field) => {
+    return fields.reduce((agg: Aggregate, field) => {
       const aggAlias = `${func}_${field as string}`;
       const fieldAlias = `$${getSchemaKey(String(field))}`;
       if (func === 'count') {
@@ -83,6 +91,17 @@ export class AggregateBuilder<Entity extends Document> {
         };
       }
       return { ...agg, [aggAlias]: { [`$${func}`]: fieldAlias } };
+    }, {});
+  }
+
+  private createGroupBySelect(fields?: (keyof Entity)[]): Record<string, string> | null {
+    if (!fields) {
+      return null;
+    }
+    return fields.reduce((id: Record<string, string>, field) => {
+      const aggAlias = `group_by_${field as string}`;
+      const fieldAlias = `$${getSchemaKey(String(field))}`;
+      return { ...id, [aggAlias]: fieldAlias };
     }, {});
   }
 }

--- a/packages/query-mongoose/src/query/filter-query.builder.ts
+++ b/packages/query-mongoose/src/query/filter-query.builder.ts
@@ -1,6 +1,6 @@
 import { AggregateQuery, Filter, Query, SortDirection, SortField } from '@nestjs-query/core';
 import { FilterQuery, Document } from 'mongoose';
-import { AggregateBuilder, MongooseAggregate } from './aggregate.builder';
+import { AggregateBuilder, MongooseGroupAndAggregate } from './aggregate.builder';
 import { getSchemaKey } from './helpers';
 import { WhereBuilder } from './where.builder';
 
@@ -13,7 +13,7 @@ type MongooseQuery<Entity extends Document> = {
 
 type MongooseAggregateQuery<Entity extends Document> = {
   filterQuery: FilterQuery<Entity>;
-  aggregate: MongooseAggregate;
+  aggregate: MongooseGroupAndAggregate;
 };
 /**
  * @internal

--- a/packages/query-mongoose/src/services/mongoose-query.service.ts
+++ b/packages/query-mongoose/src/services/mongoose-query.service.ts
@@ -68,13 +68,16 @@ export class MongooseQueryService<Entity extends Document>
     return this.Model.find(filterQuery, {}, options).exec();
   }
 
-  async aggregate(filter: Filter<Entity>, aggregateQuery: AggregateQuery<Entity>): Promise<AggregateResponse<Entity>> {
+  async aggregate(
+    filter: Filter<Entity>,
+    aggregateQuery: AggregateQuery<Entity>,
+  ): Promise<AggregateResponse<Entity>[]> {
     const { aggregate, filterQuery } = this.filterQueryBuilder.buildAggregateQuery(aggregateQuery, filter);
     const aggResult = (await this.Model.aggregate<Record<string, unknown>>([
       { $match: filterQuery },
-      { $group: { _id: null, ...aggregate } },
+      { $group: aggregate },
     ]).exec()) as Record<string, unknown>[];
-    return AggregateBuilder.convertToAggregateResponse(aggResult[0]);
+    return AggregateBuilder.convertToAggregateResponse(aggResult);
   }
 
   count(filter: Filter<Entity>): Promise<number> {

--- a/packages/query-sequelize/__tests__/services/sequelize-query.service.spec.ts
+++ b/packages/query-sequelize/__tests__/services/sequelize-query.service.spec.ts
@@ -117,29 +117,100 @@ describe('SequelizeQueryService', (): void => {
           min: ['testEntityPk', 'dateType', 'numberType', 'stringType'],
         },
       );
-      return expect(queryResult).toEqual({
-        avg: {
-          numberType: 5.5,
+      return expect(queryResult).toEqual([
+        {
+          avg: {
+            numberType: 5.5,
+          },
+          count: {
+            testEntityPk: 10,
+          },
+          max: {
+            dateType: expect.stringMatching('2020-02-10'),
+            numberType: 10,
+            stringType: 'foo9',
+            testEntityPk: 'test-entity-9',
+          },
+          min: {
+            dateType: expect.stringMatching('2020-02-01'),
+            numberType: 1,
+            stringType: 'foo1',
+            testEntityPk: 'test-entity-1',
+          },
+          sum: {
+            numberType: 55,
+          },
         },
-        count: {
-          testEntityPk: 10,
+      ]);
+    });
+
+    it('call aggregate with a group by', async () => {
+      const queryService = moduleRef.get(TestEntityService);
+      const queryResult = await queryService.aggregate(
+        {},
+        {
+          groupBy: ['boolType'],
+          count: ['testEntityPk'],
+          avg: ['numberType'],
+          sum: ['numberType'],
+          max: ['testEntityPk', 'dateType', 'numberType', 'stringType'],
+          min: ['testEntityPk', 'dateType', 'numberType', 'stringType'],
         },
-        max: {
-          dateType: expect.stringMatching('2020-02-10'),
-          numberType: 10,
-          stringType: 'foo9',
-          testEntityPk: 'test-entity-9',
+      );
+      return expect(queryResult).toEqual([
+        {
+          groupBy: {
+            boolType: 0,
+          },
+          avg: {
+            numberType: 5,
+          },
+          count: {
+            testEntityPk: 5,
+          },
+          max: {
+            dateType: expect.stringMatching('2020-02-09'),
+            numberType: 9,
+            stringType: 'foo9',
+            testEntityPk: 'test-entity-9',
+          },
+          min: {
+            dateType: expect.stringMatching('2020-02-01'),
+            numberType: 1,
+            stringType: 'foo1',
+            testEntityPk: 'test-entity-1',
+          },
+          sum: {
+            numberType: 25,
+          },
         },
-        min: {
-          dateType: expect.stringMatching('2020-02-01'),
-          numberType: 1,
-          stringType: 'foo1',
-          testEntityPk: 'test-entity-1',
+        {
+          groupBy: {
+            boolType: 1,
+          },
+          avg: {
+            numberType: 6,
+          },
+          count: {
+            testEntityPk: 5,
+          },
+          max: {
+            dateType: expect.stringMatching('2020-02-10'),
+            numberType: 10,
+            stringType: 'foo8',
+            testEntityPk: 'test-entity-8',
+          },
+          min: {
+            dateType: expect.stringMatching('2020-02-02'),
+            numberType: 2,
+            stringType: 'foo10',
+            testEntityPk: 'test-entity-10',
+          },
+          sum: {
+            numberType: 30,
+          },
         },
-        sum: {
-          numberType: 55,
-        },
-      });
+      ]);
     });
 
     it('call select with the aggregate columns and return the result with a filter', async () => {
@@ -154,29 +225,100 @@ describe('SequelizeQueryService', (): void => {
           min: ['testEntityPk', 'dateType', 'numberType', 'stringType'],
         },
       );
-      return expect(queryResult).toEqual({
-        avg: {
-          numberType: 2,
+      return expect(queryResult).toEqual([
+        {
+          avg: {
+            numberType: 2,
+          },
+          count: {
+            testEntityPk: 3,
+          },
+          max: {
+            dateType: expect.stringMatching('2020-02-03'),
+            numberType: 3,
+            stringType: 'foo3',
+            testEntityPk: 'test-entity-3',
+          },
+          min: {
+            dateType: expect.stringMatching('2020-02-01'),
+            numberType: 1,
+            stringType: 'foo1',
+            testEntityPk: 'test-entity-1',
+          },
+          sum: {
+            numberType: 6,
+          },
         },
-        count: {
-          testEntityPk: 3,
+      ]);
+    });
+
+    it('call aggregate with a group and filter', async () => {
+      const queryService = moduleRef.get(TestEntityService);
+      const queryResult = await queryService.aggregate(
+        { stringType: { in: ['foo1', 'foo2', 'foo3'] } },
+        {
+          groupBy: ['boolType'],
+          count: ['testEntityPk'],
+          avg: ['numberType'],
+          sum: ['numberType'],
+          max: ['testEntityPk', 'dateType', 'numberType', 'stringType'],
+          min: ['testEntityPk', 'dateType', 'numberType', 'stringType'],
         },
-        max: {
-          dateType: expect.stringMatching('2020-02-03'),
-          numberType: 3,
-          stringType: 'foo3',
-          testEntityPk: 'test-entity-3',
+      );
+      return expect(queryResult).toEqual([
+        {
+          groupBy: {
+            boolType: 0,
+          },
+          avg: {
+            numberType: 2,
+          },
+          count: {
+            testEntityPk: 2,
+          },
+          max: {
+            dateType: expect.stringMatching('2020-02-03'),
+            numberType: 3,
+            stringType: 'foo3',
+            testEntityPk: 'test-entity-3',
+          },
+          min: {
+            dateType: expect.stringMatching('2020-02-01'),
+            numberType: 1,
+            stringType: 'foo1',
+            testEntityPk: 'test-entity-1',
+          },
+          sum: {
+            numberType: 4,
+          },
         },
-        min: {
-          dateType: expect.stringMatching('2020-02-01'),
-          numberType: 1,
-          stringType: 'foo1',
-          testEntityPk: 'test-entity-1',
+        {
+          groupBy: {
+            boolType: 1,
+          },
+          avg: {
+            numberType: 2,
+          },
+          count: {
+            testEntityPk: 1,
+          },
+          max: {
+            dateType: expect.stringMatching('2020-02-02'),
+            numberType: 2,
+            stringType: 'foo2',
+            testEntityPk: 'test-entity-2',
+          },
+          min: {
+            dateType: expect.stringMatching('2020-02-02'),
+            numberType: 2,
+            stringType: 'foo2',
+            testEntityPk: 'test-entity-2',
+          },
+          sum: {
+            numberType: 2,
+          },
         },
-        sum: {
-          numberType: 6,
-        },
-      });
+      ]);
     });
   });
 
@@ -294,11 +436,13 @@ describe('SequelizeQueryService', (): void => {
           { relationName: { isNot: null } },
           { count: ['testRelationPk'] },
         );
-        return expect(aggResult).toEqual({
-          count: {
-            testRelationPk: 3,
+        return expect(aggResult).toEqual([
+          {
+            count: {
+              testRelationPk: 3,
+            },
           },
-        });
+        ]);
       });
     });
 
@@ -323,63 +467,167 @@ describe('SequelizeQueryService', (): void => {
           new Map([
             [
               entities[0],
-              {
-                count: {
-                  relationName: 3,
-                  testEntityId: 3,
-                  testRelationPk: 3,
+              [
+                {
+                  count: {
+                    relationName: 3,
+                    testEntityId: 3,
+                    testRelationPk: 3,
+                  },
+                  max: {
+                    relationName: 'foo1-test-relation-two',
+                    testEntityId: 'test-entity-1',
+                    testRelationPk: 'test-relations-test-entity-1-3',
+                  },
+                  min: {
+                    relationName: 'foo1-test-relation-one',
+                    testEntityId: 'test-entity-1',
+                    testRelationPk: 'test-relations-test-entity-1-1',
+                  },
                 },
-                max: {
-                  relationName: 'foo1-test-relation-two',
-                  testEntityId: 'test-entity-1',
-                  testRelationPk: 'test-relations-test-entity-1-3',
-                },
-                min: {
-                  relationName: 'foo1-test-relation-one',
-                  testEntityId: 'test-entity-1',
-                  testRelationPk: 'test-relations-test-entity-1-1',
-                },
-              },
+              ],
             ],
             [
               entities[1],
-              {
-                count: {
-                  relationName: 3,
-                  testEntityId: 3,
-                  testRelationPk: 3,
+              [
+                {
+                  count: {
+                    relationName: 3,
+                    testEntityId: 3,
+                    testRelationPk: 3,
+                  },
+                  max: {
+                    relationName: 'foo2-test-relation-two',
+                    testEntityId: 'test-entity-2',
+                    testRelationPk: 'test-relations-test-entity-2-3',
+                  },
+                  min: {
+                    relationName: 'foo2-test-relation-one',
+                    testEntityId: 'test-entity-2',
+                    testRelationPk: 'test-relations-test-entity-2-1',
+                  },
                 },
-                max: {
-                  relationName: 'foo2-test-relation-two',
-                  testEntityId: 'test-entity-2',
-                  testRelationPk: 'test-relations-test-entity-2-3',
-                },
-                min: {
-                  relationName: 'foo2-test-relation-one',
-                  testEntityId: 'test-entity-2',
-                  testRelationPk: 'test-relations-test-entity-2-1',
-                },
-              },
+              ],
             ],
             [
               entities[2],
-              {
-                count: {
-                  relationName: 3,
-                  testEntityId: 3,
-                  testRelationPk: 3,
+              [
+                {
+                  count: {
+                    relationName: 3,
+                    testEntityId: 3,
+                    testRelationPk: 3,
+                  },
+                  max: {
+                    relationName: 'foo3-test-relation-two',
+                    testEntityId: 'test-entity-3',
+                    testRelationPk: 'test-relations-test-entity-3-3',
+                  },
+                  min: {
+                    relationName: 'foo3-test-relation-one',
+                    testEntityId: 'test-entity-3',
+                    testRelationPk: 'test-relations-test-entity-3-1',
+                  },
                 },
-                max: {
-                  relationName: 'foo3-test-relation-two',
-                  testEntityId: 'test-entity-3',
-                  testRelationPk: 'test-relations-test-entity-3-3',
+              ],
+            ],
+          ]),
+        );
+      });
+
+      it('aggregate and group for each entities relation', async () => {
+        const entities = PLAIN_TEST_ENTITIES.slice(0, 3).map((pe) => TestEntity.build(pe));
+        const queryService = moduleRef.get(TestEntityService);
+        const queryResult = await queryService.aggregateRelations(
+          TestRelation,
+          'testRelations',
+          entities,
+          {},
+          {
+            groupBy: ['testEntityId'],
+            count: ['testRelationPk', 'relationName', 'testEntityId'],
+            min: ['testRelationPk', 'relationName', 'testEntityId'],
+            max: ['testRelationPk', 'relationName', 'testEntityId'],
+          },
+        );
+
+        expect(queryResult.size).toBe(3);
+        expect(queryResult).toEqual(
+          new Map([
+            [
+              entities[0],
+              [
+                {
+                  groupBy: {
+                    testEntityId: 'test-entity-1',
+                  },
+                  count: {
+                    relationName: 3,
+                    testEntityId: 3,
+                    testRelationPk: 3,
+                  },
+                  max: {
+                    relationName: 'foo1-test-relation-two',
+                    testEntityId: 'test-entity-1',
+                    testRelationPk: 'test-relations-test-entity-1-3',
+                  },
+                  min: {
+                    relationName: 'foo1-test-relation-one',
+                    testEntityId: 'test-entity-1',
+                    testRelationPk: 'test-relations-test-entity-1-1',
+                  },
                 },
-                min: {
-                  relationName: 'foo3-test-relation-one',
-                  testEntityId: 'test-entity-3',
-                  testRelationPk: 'test-relations-test-entity-3-1',
+              ],
+            ],
+            [
+              entities[1],
+              [
+                {
+                  groupBy: {
+                    testEntityId: 'test-entity-2',
+                  },
+                  count: {
+                    relationName: 3,
+                    testEntityId: 3,
+                    testRelationPk: 3,
+                  },
+                  max: {
+                    relationName: 'foo2-test-relation-two',
+                    testEntityId: 'test-entity-2',
+                    testRelationPk: 'test-relations-test-entity-2-3',
+                  },
+                  min: {
+                    relationName: 'foo2-test-relation-one',
+                    testEntityId: 'test-entity-2',
+                    testRelationPk: 'test-relations-test-entity-2-1',
+                  },
                 },
-              },
+              ],
+            ],
+            [
+              entities[2],
+              [
+                {
+                  groupBy: {
+                    testEntityId: 'test-entity-3',
+                  },
+                  count: {
+                    relationName: 3,
+                    testEntityId: 3,
+                    testRelationPk: 3,
+                  },
+                  max: {
+                    relationName: 'foo3-test-relation-two',
+                    testEntityId: 'test-entity-3',
+                    testRelationPk: 'test-relations-test-entity-3-3',
+                  },
+                  min: {
+                    relationName: 'foo3-test-relation-one',
+                    testEntityId: 'test-entity-3',
+                    testRelationPk: 'test-relations-test-entity-3-1',
+                  },
+                },
+              ],
             ],
           ]),
         );
@@ -407,43 +655,47 @@ describe('SequelizeQueryService', (): void => {
           new Map([
             [
               entities[0],
-              {
-                count: {
-                  relationName: 3,
-                  testEntityId: 3,
-                  testRelationPk: 3,
+              [
+                {
+                  count: {
+                    relationName: 3,
+                    testEntityId: 3,
+                    testRelationPk: 3,
+                  },
+                  max: {
+                    relationName: 'foo1-test-relation-two',
+                    testEntityId: 'test-entity-1',
+                    testRelationPk: 'test-relations-test-entity-1-3',
+                  },
+                  min: {
+                    relationName: 'foo1-test-relation-one',
+                    testEntityId: 'test-entity-1',
+                    testRelationPk: 'test-relations-test-entity-1-1',
+                  },
                 },
-                max: {
-                  relationName: 'foo1-test-relation-two',
-                  testEntityId: 'test-entity-1',
-                  testRelationPk: 'test-relations-test-entity-1-3',
-                },
-                min: {
-                  relationName: 'foo1-test-relation-one',
-                  testEntityId: 'test-entity-1',
-                  testRelationPk: 'test-relations-test-entity-1-1',
-                },
-              },
+              ],
             ],
             [
               { testEntityPk: 'does-not-exist' } as TestEntity,
-              {
-                count: {
-                  relationName: 0,
-                  testEntityId: 0,
-                  testRelationPk: 0,
+              [
+                {
+                  count: {
+                    relationName: 0,
+                    testEntityId: 0,
+                    testRelationPk: 0,
+                  },
+                  max: {
+                    relationName: null,
+                    testEntityId: null,
+                    testRelationPk: null,
+                  },
+                  min: {
+                    relationName: null,
+                    testEntityId: null,
+                    testRelationPk: null,
+                  },
                 },
-                max: {
-                  relationName: null,
-                  testEntityId: null,
-                  testRelationPk: null,
-                },
-                min: {
-                  relationName: null,
-                  testEntityId: null,
-                  testRelationPk: null,
-                },
-              },
+              ],
             ],
           ]),
         );

--- a/packages/query-sequelize/package.json
+++ b/packages/query-sequelize/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "@nestjs-query/core": "0.24.4",
     "lodash.pick": "4.4.0",
-    "tslib": "^2.1.0"
+    "tslib": "^2.1.0",
+    "camel-case": "^4.1.2"
   },
   "peerDependencies": {
     "@nestjs/common": "^7.0.0",

--- a/packages/query-sequelize/src/services/sequelize-query.service.ts
+++ b/packages/query-sequelize/src/services/sequelize-query.service.ts
@@ -62,12 +62,12 @@ export class SequelizeQueryService<Entity extends Model<Entity, Partial<Entity>>
     return this.model.findAll<Entity>(this.filterQueryBuilder.findOptions(query));
   }
 
-  async aggregate(filter: Filter<Entity>, aggregate: AggregateQuery<Entity>): Promise<AggregateResponse<Entity>> {
-    const result = await this.model.findOne(this.filterQueryBuilder.aggregateOptions({ filter }, aggregate));
+  async aggregate(filter: Filter<Entity>, aggregate: AggregateQuery<Entity>): Promise<AggregateResponse<Entity>[]> {
+    const result = await this.model.findAll(this.filterQueryBuilder.aggregateOptions({ filter }, aggregate));
     if (!result) {
-      return {};
+      return [{}];
     }
-    return AggregateBuilder.convertToAggregateResponse((result as unknown) as Record<string, unknown>);
+    return AggregateBuilder.convertToAggregateResponse((result as unknown) as Record<string, unknown>[]);
   }
 
   async count(filter: Filter<Entity>): Promise<number> {

--- a/packages/query-typegoose/__tests__/query/aggregate.builder.spec.ts
+++ b/packages/query-typegoose/__tests__/query/aggregate.builder.spec.ts
@@ -1,70 +1,72 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { AggregateQuery } from '@nestjs-query/core';
 import { TestEntity } from '../__fixtures__/test.entity';
-import { AggregateBuilder, TypegooseAggregate } from '../../src/query';
+import { AggregateBuilder } from '../../src/query';
 
 describe('AggregateBuilder', (): void => {
   const createAggregateBuilder = () => new AggregateBuilder<TestEntity>();
-
-  const assertQuery = (agg: AggregateQuery<TestEntity>, expected: TypegooseAggregate): void => {
-    const actual = createAggregateBuilder().build(agg);
-    expect(actual).toEqual(expected);
-  };
 
   it('should throw an error if no selects are generated', (): void => {
     expect(() => createAggregateBuilder().build({})).toThrow('No aggregate fields found.');
   });
 
-  it('or multiple operators for a single field together', (): void => {
-    assertQuery(
-      {
-        count: ['id', 'stringType'],
-        avg: ['numberType'],
-        sum: ['numberType'],
-        max: ['stringType', 'dateType', 'numberType'],
-        min: ['stringType', 'dateType', 'numberType'],
+  it('should create an aggregate query', (): void => {
+    const agg: AggregateQuery<TestEntity> = {
+      count: ['id', 'stringType'],
+      avg: ['numberType'],
+      sum: ['numberType'],
+      max: ['stringType', 'dateType', 'numberType'],
+      min: ['stringType', 'dateType', 'numberType'],
+    };
+    expect(createAggregateBuilder().build(agg)).toEqual({
+      _id: null,
+      avg_numberType: { $avg: '$numberType' },
+      count_id: { $sum: { $cond: { else: 1, if: { $in: [{ $type: '$_id' }, ['missing', 'null']] }, then: 0 } } },
+      count_stringType: {
+        $sum: { $cond: { else: 1, if: { $in: [{ $type: '$stringType' }, ['missing', 'null']] }, then: 0 } },
       },
-      {
-        avg_numberType: { $avg: '$numberType' },
-        count_id: { $sum: { $cond: { else: 1, if: { $in: [{ $type: '$_id' }, ['missing', 'null']] }, then: 0 } } },
-        count_stringType: {
-          $sum: { $cond: { else: 1, if: { $in: [{ $type: '$stringType' }, ['missing', 'null']] }, then: 0 } },
-        },
-        max_dateType: { $max: '$dateType' },
-        max_numberType: { $max: '$numberType' },
-        max_stringType: { $max: '$stringType' },
-        min_dateType: { $min: '$dateType' },
-        min_numberType: { $min: '$numberType' },
-        min_stringType: { $min: '$stringType' },
-        sum_numberType: { $sum: '$numberType' },
-      },
-    );
+      max_dateType: { $max: '$dateType' },
+      max_numberType: { $max: '$numberType' },
+      max_stringType: { $max: '$stringType' },
+      min_dateType: { $min: '$dateType' },
+      min_numberType: { $min: '$numberType' },
+      min_stringType: { $min: '$stringType' },
+      sum_numberType: { $sum: '$numberType' },
+    });
   });
 
   describe('.convertToAggregateResponse', () => {
     it('should convert a flat response into an Aggregtate response', () => {
-      const dbResult = {
-        count_id: 10,
-        sum_numberType: 55,
-        avg_numberType: 5,
-        max_stringType: 'z',
-        max_numberType: 10,
-        min_stringType: 'a',
-        min_numberType: 1,
-      };
-      expect(AggregateBuilder.convertToAggregateResponse<TestEntity>(dbResult)).toEqual({
-        count: { id: 10 },
-        sum: { numberType: 55 },
-        avg: { numberType: 5 },
-        max: { stringType: 'z', numberType: 10 },
-        min: { stringType: 'a', numberType: 1 },
-      });
+      const dbResult = [
+        {
+          _id: { group_by_stringType: 'z' },
+          count_id: 10,
+          sum_numberType: 55,
+          avg_numberType: 5,
+          max_stringType: 'z',
+          max_numberType: 10,
+          min_stringType: 'a',
+          min_numberType: 1,
+        },
+      ];
+      expect(AggregateBuilder.convertToAggregateResponse<TestEntity>(dbResult)).toEqual([
+        {
+          groupBy: { stringType: 'z' },
+          count: { id: 10 },
+          sum: { numberType: 55 },
+          avg: { numberType: 5 },
+          max: { stringType: 'z', numberType: 10 },
+          min: { stringType: 'a', numberType: 1 },
+        },
+      ]);
     });
 
     it('should throw an error if a column is not expected', () => {
-      const dbResult = {
-        COUNTtestEntityPk: 10,
-      };
+      const dbResult = [
+        {
+          COUNTtestEntityPk: 10,
+        },
+      ];
       expect(() => AggregateBuilder.convertToAggregateResponse<TestEntity>(dbResult)).toThrow(
         'Unknown aggregate column encountered.',
       );

--- a/packages/query-typegoose/__tests__/services/typegoose-query.service.spec.ts
+++ b/packages/query-typegoose/__tests__/services/typegoose-query.service.spec.ts
@@ -235,32 +235,6 @@ describe('TypegooseQueryService', () => {
       return expect(queryResult).toEqual([
         {
           groupBy: {
-            boolType: true,
-          },
-          avg: {
-            numberType: 6,
-          },
-          count: {
-            id: 5,
-          },
-          max: {
-            dateType: TEST_ENTITIES[9].dateType,
-            numberType: 10,
-            stringType: 'foo8',
-            id: expect.any(ObjectId),
-          },
-          min: {
-            dateType: TEST_ENTITIES[1].dateType,
-            numberType: 2,
-            stringType: 'foo10',
-            id: expect.any(ObjectId),
-          },
-          sum: {
-            numberType: 30,
-          },
-        },
-        {
-          groupBy: {
             boolType: false,
           },
           avg: {
@@ -283,6 +257,32 @@ describe('TypegooseQueryService', () => {
           },
           sum: {
             numberType: 25,
+          },
+        },
+        {
+          groupBy: {
+            boolType: true,
+          },
+          avg: {
+            numberType: 6,
+          },
+          count: {
+            id: 5,
+          },
+          max: {
+            dateType: TEST_ENTITIES[9].dateType,
+            numberType: 10,
+            stringType: 'foo8',
+            id: expect.any(ObjectId),
+          },
+          min: {
+            dateType: TEST_ENTITIES[1].dateType,
+            numberType: 2,
+            stringType: 'foo10',
+            id: expect.any(ObjectId),
+          },
+          sum: {
+            numberType: 30,
           },
         },
       ]);

--- a/packages/query-typegoose/package.json
+++ b/packages/query-typegoose/package.json
@@ -21,7 +21,8 @@
     "@nestjs-query/core": "0.24.4",
     "lodash.escaperegexp": "^4.1.2",
     "lodash.merge": "^4.6.2",
-    "tslib": "^2.1.0"
+    "tslib": "^2.1.0",
+    "camel-case": "^4.1.2"
   },
   "peerDependencies": {
     "@nestjs/common": "^7.0.0",

--- a/packages/query-typegoose/src/query/aggregate.builder.ts
+++ b/packages/query-typegoose/src/query/aggregate.builder.ts
@@ -1,6 +1,7 @@
 import { AggregateQuery, AggregateResponse } from '@nestjs-query/core';
 import { BadRequestException } from '@nestjs/common';
 import { DocumentType } from '@typegoose/typegoose';
+import { camelCase } from 'camel-case';
 import { getSchemaKey } from './helpers';
 
 enum AggregateFuncs {
@@ -10,14 +11,11 @@ enum AggregateFuncs {
   MAX = 'max',
   MIN = 'min',
 }
+type Aggregate = Record<string, Record<string, unknown>>;
+type Group = { _id: Record<string, string> | null };
+export type TypegooseGroupAndAggregate = (Aggregate & Group) | Record<string, never>;
 
-export type TypegooseAggregate = {
-  [k: string]: {
-    [o: string]: unknown;
-  };
-};
-
-const AGG_REGEXP = /(avg|sum|count|max|min)_(.*)/;
+const AGG_REGEXP = /(avg|sum|count|max|min|group_by)_(.*)/;
 
 /**
  * @internal
@@ -25,14 +23,24 @@ const AGG_REGEXP = /(avg|sum|count|max|min)_(.*)/;
  */
 export class AggregateBuilder<Entity> {
   // eslint-disable-next-line @typescript-eslint/no-shadow
-  static convertToAggregateResponse<Entity>({ _id, ...response }: Record<string, unknown>): AggregateResponse<Entity> {
+  static convertToAggregateResponse<Entity>(aggregates: Record<string, unknown>[]): AggregateResponse<Entity>[] {
+    return aggregates.map(({ _id, ...response }) => {
+      return { ...this.extractResponse(_id as Record<string, unknown>), ...this.extractResponse(response) };
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-shadow
+  private static extractResponse<Entity>(response?: Record<string, unknown>): AggregateResponse<Entity> {
+    if (!response) {
+      return {};
+    }
     return Object.keys(response).reduce((agg, resultField: string) => {
       const matchResult = AGG_REGEXP.exec(resultField);
       if (!matchResult) {
         throw new Error('Unknown aggregate column encountered.');
       }
       const [matchedFunc, matchedFieldName] = matchResult.slice(1);
-      const aggFunc = matchedFunc.toLowerCase() as keyof AggregateResponse<Entity>;
+      const aggFunc = camelCase(matchedFunc.toLowerCase()) as keyof AggregateResponse<Entity>;
       const fieldName = matchedFieldName as keyof Entity;
       const aggResult = agg[aggFunc] || {};
       return {
@@ -47,25 +55,25 @@ export class AggregateBuilder<Entity> {
    * Builds a aggregate SELECT clause from a aggregate.
    * @param aggregate - the aggregates to select.
    */
-  build(aggregate: AggregateQuery<DocumentType<Entity>>): TypegooseAggregate {
-    const query = {
+  build(aggregate: AggregateQuery<DocumentType<Entity>>): TypegooseGroupAndAggregate {
+    const aggSelect: Aggregate = {
       ...this.createAggSelect(AggregateFuncs.COUNT, aggregate.count),
       ...this.createAggSelect(AggregateFuncs.SUM, aggregate.sum),
       ...this.createAggSelect(AggregateFuncs.AVG, aggregate.avg),
       ...this.createAggSelect(AggregateFuncs.MAX, aggregate.max),
       ...this.createAggSelect(AggregateFuncs.MIN, aggregate.min),
     };
-    if (!Object.keys(query).length) {
+    if (!Object.keys(aggSelect).length) {
       throw new BadRequestException('No aggregate fields found.');
     }
-    return query;
+    return { ...aggSelect, _id: this.createGroupBySelect(aggregate.groupBy) } as TypegooseGroupAndAggregate;
   }
 
-  private createAggSelect(func: AggregateFuncs, fields?: (keyof DocumentType<Entity>)[]): TypegooseAggregate {
+  private createAggSelect(func: AggregateFuncs, fields?: (keyof DocumentType<Entity>)[]): Aggregate {
     if (!fields) {
       return {};
     }
-    return fields.reduce((agg: TypegooseAggregate, field) => {
+    return fields.reduce((agg: Aggregate, field) => {
       const aggAlias = `${func}_${field as string}`;
       const fieldAlias = `$${getSchemaKey(String(field))}`;
       if (func === 'count') {
@@ -83,6 +91,17 @@ export class AggregateBuilder<Entity> {
         };
       }
       return { ...agg, [aggAlias]: { [`$${func}`]: fieldAlias } };
+    }, {});
+  }
+
+  private createGroupBySelect(fields?: (keyof DocumentType<Entity>)[]): Record<string, string> | null {
+    if (!fields) {
+      return null;
+    }
+    return fields.reduce((id: Record<string, string>, field) => {
+      const aggAlias = `group_by_${field as string}`;
+      const fieldAlias = `$${getSchemaKey(String(field))}`;
+      return { ...id, [aggAlias]: fieldAlias };
     }, {});
   }
 }

--- a/packages/query-typegoose/src/query/filter-query.builder.ts
+++ b/packages/query-typegoose/src/query/filter-query.builder.ts
@@ -1,7 +1,7 @@
 import { AggregateQuery, Filter, Query, SortDirection, SortField } from '@nestjs-query/core';
 import { FilterQuery } from 'mongoose';
 import { DocumentType } from '@typegoose/typegoose';
-import { AggregateBuilder, TypegooseAggregate } from './aggregate.builder';
+import { AggregateBuilder, TypegooseGroupAndAggregate } from './aggregate.builder';
 import { getSchemaKey } from './helpers';
 import { WhereBuilder } from './where.builder';
 
@@ -14,7 +14,7 @@ type TypegooseQuery<Entity> = {
 
 type TypegooseAggregateQuery<Entity> = {
   filterQuery: FilterQuery<Entity>;
-  aggregate: TypegooseAggregate;
+  aggregate: TypegooseGroupAndAggregate;
 };
 /**
  * @internal

--- a/packages/query-typegoose/src/services/typegoose-query-service.ts
+++ b/packages/query-typegoose/src/services/typegoose-query-service.ts
@@ -52,13 +52,16 @@ export class TypegooseQueryService<Entity extends Base>
     return entities;
   }
 
-  async aggregate(filter: Filter<Entity>, aggregateQuery: AggregateQuery<Entity>): Promise<AggregateResponse<Entity>> {
+  async aggregate(
+    filter: Filter<Entity>,
+    aggregateQuery: AggregateQuery<Entity>,
+  ): Promise<AggregateResponse<Entity>[]> {
     const { aggregate, filterQuery } = this.filterQueryBuilder.buildAggregateQuery(aggregateQuery, filter);
     const aggResult = (await this.Model.aggregate<Record<string, unknown>>([
       { $match: filterQuery },
-      { $group: { _id: null, ...aggregate } },
+      { $group: aggregate },
     ]).exec()) as Record<string, unknown>[];
-    return AggregateBuilder.convertToAggregateResponse(aggResult[0]);
+    return AggregateBuilder.convertToAggregateResponse(aggResult);
   }
 
   count(filter: Filter<Entity>): Promise<number> {

--- a/packages/query-typegoose/src/services/typegoose-query-service.ts
+++ b/packages/query-typegoose/src/services/typegoose-query-service.ts
@@ -56,11 +56,15 @@ export class TypegooseQueryService<Entity extends Base>
     filter: Filter<Entity>,
     aggregateQuery: AggregateQuery<Entity>,
   ): Promise<AggregateResponse<Entity>[]> {
-    const { aggregate, filterQuery } = this.filterQueryBuilder.buildAggregateQuery(aggregateQuery, filter);
-    const aggResult = (await this.Model.aggregate<Record<string, unknown>>([
-      { $match: filterQuery },
-      { $group: aggregate },
-    ]).exec()) as Record<string, unknown>[];
+    const { aggregate, filterQuery, options } = this.filterQueryBuilder.buildAggregateQuery(aggregateQuery, filter);
+    const aggPipeline: unknown[] = [{ $match: filterQuery }, { $group: aggregate }];
+    if (options.sort) {
+      aggPipeline.push({ $sort: options.sort ?? {} });
+    }
+    const aggResult = (await this.Model.aggregate<Record<string, unknown>>(aggPipeline).exec()) as Record<
+      string,
+      unknown
+    >[];
     return AggregateBuilder.convertToAggregateResponse(aggResult);
   }
 

--- a/packages/query-typeorm/__tests__/query/aggregate.builder.spec.ts
+++ b/packages/query-typeorm/__tests__/query/aggregate.builder.spec.ts
@@ -23,7 +23,7 @@ describe('AggregateBuilder', (): void => {
     expect(() => createAggregateBuilder().build(getQueryBuilder(), {})).toThrow('No aggregate fields found.');
   });
 
-  it('or multiple operators for a single field together', (): void => {
+  it('should create selects for all aggregate functions', (): void => {
     assertSQL(
       {
         count: ['testEntityPk'],
@@ -47,30 +47,53 @@ describe('AggregateBuilder', (): void => {
     );
   });
 
+  it('should create selects for all aggregate functions and group bys', (): void => {
+    assertSQL(
+      {
+        groupBy: ['stringType', 'boolType'],
+        count: ['testEntityPk'],
+      },
+      'SELECT ' +
+        '"TestEntity"."string_type" AS "GROUP_BY_stringType", ' +
+        '"TestEntity"."bool_type" AS "GROUP_BY_boolType", ' +
+        'COUNT("TestEntity"."test_entity_pk") AS "COUNT_testEntityPk" ' +
+        'FROM "test_entity" "TestEntity"',
+      [],
+    );
+  });
+
   describe('.convertToAggregateResponse', () => {
     it('should convert a flat response into an Aggregtate response', () => {
-      const dbResult = {
-        COUNT_testEntityPk: 10,
-        SUM_numberType: 55,
-        AVG_numberType: 5,
-        MAX_stringType: 'z',
-        MAX_numberType: 10,
-        MIN_stringType: 'a',
-        MIN_numberType: 1,
-      };
-      expect(AggregateBuilder.convertToAggregateResponse<TestEntity>(dbResult)).toEqual({
-        count: { testEntityPk: 10 },
-        sum: { numberType: 55 },
-        avg: { numberType: 5 },
-        max: { stringType: 'z', numberType: 10 },
-        min: { stringType: 'a', numberType: 1 },
-      });
+      const dbResult = [
+        {
+          GROUP_BY_stringType: 'z',
+          COUNT_testEntityPk: 10,
+          SUM_numberType: 55,
+          AVG_numberType: 5,
+          MAX_stringType: 'z',
+          MAX_numberType: 10,
+          MIN_stringType: 'a',
+          MIN_numberType: 1,
+        },
+      ];
+      expect(AggregateBuilder.convertToAggregateResponse<TestEntity>(dbResult)).toEqual([
+        {
+          groupBy: { stringType: 'z' },
+          count: { testEntityPk: 10 },
+          sum: { numberType: 55 },
+          avg: { numberType: 5 },
+          max: { stringType: 'z', numberType: 10 },
+          min: { stringType: 'a', numberType: 1 },
+        },
+      ]);
     });
 
     it('should throw an error if a column is not expected', () => {
-      const dbResult = {
-        COUNTtestEntityPk: 10,
-      };
+      const dbResult = [
+        {
+          COUNTtestEntityPk: 10,
+        },
+      ];
       expect(() => AggregateBuilder.convertToAggregateResponse<TestEntity>(dbResult)).toThrow(
         'Unknown aggregate column encountered.',
       );

--- a/packages/query-typeorm/__tests__/services/typeorm-query.service.spec.ts
+++ b/packages/query-typeorm/__tests__/services/typeorm-query.service.spec.ts
@@ -272,29 +272,100 @@ describe('TypeOrmQueryService', (): void => {
           min: ['testEntityPk', 'dateType', 'numberType', 'stringType'],
         },
       );
-      return expect(queryResult).toEqual({
-        avg: {
-          numberType: 5.5,
+      return expect(queryResult).toEqual([
+        {
+          avg: {
+            numberType: 5.5,
+          },
+          count: {
+            testEntityPk: 10,
+          },
+          max: {
+            dateType: expect.stringMatching('2020-02-10'),
+            numberType: 10,
+            stringType: 'foo9',
+            testEntityPk: 'test-entity-9',
+          },
+          min: {
+            dateType: expect.stringMatching('2020-02-01'),
+            numberType: 1,
+            stringType: 'foo1',
+            testEntityPk: 'test-entity-1',
+          },
+          sum: {
+            numberType: 55,
+          },
         },
-        count: {
-          testEntityPk: 10,
+      ]);
+    });
+
+    it('call aggregate with a group by', async () => {
+      const queryService = moduleRef.get(TestEntityService);
+      const queryResult = await queryService.aggregate(
+        {},
+        {
+          groupBy: ['boolType'],
+          count: ['testEntityPk'],
+          avg: ['numberType'],
+          sum: ['numberType'],
+          max: ['testEntityPk', 'dateType', 'numberType', 'stringType'],
+          min: ['testEntityPk', 'dateType', 'numberType', 'stringType'],
         },
-        max: {
-          dateType: expect.stringMatching('2020-02-10'),
-          numberType: 10,
-          stringType: 'foo9',
-          testEntityPk: 'test-entity-9',
+      );
+      return expect(queryResult).toEqual([
+        {
+          groupBy: {
+            boolType: 0,
+          },
+          avg: {
+            numberType: 5,
+          },
+          count: {
+            testEntityPk: 5,
+          },
+          max: {
+            dateType: expect.stringMatching('2020-02-09'),
+            numberType: 9,
+            stringType: 'foo9',
+            testEntityPk: 'test-entity-9',
+          },
+          min: {
+            dateType: expect.stringMatching('2020-02-01'),
+            numberType: 1,
+            stringType: 'foo1',
+            testEntityPk: 'test-entity-1',
+          },
+          sum: {
+            numberType: 25,
+          },
         },
-        min: {
-          dateType: expect.stringMatching('2020-02-01'),
-          numberType: 1,
-          stringType: 'foo1',
-          testEntityPk: 'test-entity-1',
+        {
+          groupBy: {
+            boolType: 1,
+          },
+          avg: {
+            numberType: 6,
+          },
+          count: {
+            testEntityPk: 5,
+          },
+          max: {
+            dateType: expect.stringMatching('2020-02-10'),
+            numberType: 10,
+            stringType: 'foo8',
+            testEntityPk: 'test-entity-8',
+          },
+          min: {
+            dateType: expect.stringMatching('2020-02-02'),
+            numberType: 2,
+            stringType: 'foo10',
+            testEntityPk: 'test-entity-10',
+          },
+          sum: {
+            numberType: 30,
+          },
         },
-        sum: {
-          numberType: 55,
-        },
-      });
+      ]);
     });
 
     it('call select with the aggregate columns and return the result with a filter', async () => {
@@ -309,29 +380,100 @@ describe('TypeOrmQueryService', (): void => {
           min: ['testEntityPk', 'dateType', 'numberType', 'stringType'],
         },
       );
-      return expect(queryResult).toEqual({
-        avg: {
-          numberType: 2,
+      return expect(queryResult).toEqual([
+        {
+          avg: {
+            numberType: 2,
+          },
+          count: {
+            testEntityPk: 3,
+          },
+          max: {
+            dateType: expect.stringMatching('2020-02-03'),
+            numberType: 3,
+            stringType: 'foo3',
+            testEntityPk: 'test-entity-3',
+          },
+          min: {
+            dateType: expect.stringMatching('2020-02-01'),
+            numberType: 1,
+            stringType: 'foo1',
+            testEntityPk: 'test-entity-1',
+          },
+          sum: {
+            numberType: 6,
+          },
         },
-        count: {
-          testEntityPk: 3,
+      ]);
+    });
+
+    it('call aggregate with a group and filter', async () => {
+      const queryService = moduleRef.get(TestEntityService);
+      const queryResult = await queryService.aggregate(
+        { stringType: { in: ['foo1', 'foo2', 'foo3'] } },
+        {
+          groupBy: ['boolType'],
+          count: ['testEntityPk'],
+          avg: ['numberType'],
+          sum: ['numberType'],
+          max: ['testEntityPk', 'dateType', 'numberType', 'stringType'],
+          min: ['testEntityPk', 'dateType', 'numberType', 'stringType'],
         },
-        max: {
-          dateType: expect.stringMatching('2020-02-03'),
-          numberType: 3,
-          stringType: 'foo3',
-          testEntityPk: 'test-entity-3',
+      );
+      return expect(queryResult).toEqual([
+        {
+          groupBy: {
+            boolType: 0,
+          },
+          avg: {
+            numberType: 2,
+          },
+          count: {
+            testEntityPk: 2,
+          },
+          max: {
+            dateType: expect.stringMatching('2020-02-03'),
+            numberType: 3,
+            stringType: 'foo3',
+            testEntityPk: 'test-entity-3',
+          },
+          min: {
+            dateType: expect.stringMatching('2020-02-01'),
+            numberType: 1,
+            stringType: 'foo1',
+            testEntityPk: 'test-entity-1',
+          },
+          sum: {
+            numberType: 4,
+          },
         },
-        min: {
-          dateType: expect.stringMatching('2020-02-01'),
-          numberType: 1,
-          stringType: 'foo1',
-          testEntityPk: 'test-entity-1',
+        {
+          groupBy: {
+            boolType: 1,
+          },
+          avg: {
+            numberType: 2,
+          },
+          count: {
+            testEntityPk: 1,
+          },
+          max: {
+            dateType: expect.stringMatching('2020-02-02'),
+            numberType: 2,
+            stringType: 'foo2',
+            testEntityPk: 'test-entity-2',
+          },
+          min: {
+            dateType: expect.stringMatching('2020-02-02'),
+            numberType: 2,
+            stringType: 'foo2',
+            testEntityPk: 'test-entity-2',
+          },
+          sum: {
+            numberType: 2,
+          },
         },
-        sum: {
-          numberType: 6,
-        },
-      });
+      ]);
     });
   });
 
@@ -492,11 +634,13 @@ describe('TypeOrmQueryService', (): void => {
           {},
           { count: ['testRelationPk'] },
         );
-        return expect(aggResult).toEqual({
-          count: {
-            testRelationPk: 3,
+        return expect(aggResult).toEqual([
+          {
+            count: {
+              testRelationPk: 3,
+            },
           },
-        });
+        ]);
       });
 
       it('should apply a filter', async () => {
@@ -508,16 +652,18 @@ describe('TypeOrmQueryService', (): void => {
           { testRelationPk: { notLike: '%-1' } },
           { count: ['testRelationPk'] },
         );
-        return expect(aggResult).toEqual({
-          count: {
-            testRelationPk: 2,
+        return expect(aggResult).toEqual([
+          {
+            count: {
+              testRelationPk: 2,
+            },
           },
-        });
+        ]);
       });
     });
 
     describe('with multiple entities', () => {
-      it('call select and return the result', async () => {
+      it('aggregate for each entities relation', async () => {
         const entities = TEST_ENTITIES.slice(0, 3);
         const queryService = moduleRef.get(TestEntityService);
         const queryResult = await queryService.aggregateRelations(
@@ -537,63 +683,167 @@ describe('TypeOrmQueryService', (): void => {
           new Map([
             [
               entities[0],
-              {
-                count: {
-                  relationName: 3,
-                  testEntityId: 3,
-                  testRelationPk: 3,
+              [
+                {
+                  count: {
+                    relationName: 3,
+                    testEntityId: 3,
+                    testRelationPk: 3,
+                  },
+                  max: {
+                    relationName: 'foo1-test-relation-two',
+                    testEntityId: 'test-entity-1',
+                    testRelationPk: 'test-relations-test-entity-1-3',
+                  },
+                  min: {
+                    relationName: 'foo1-test-relation-one',
+                    testEntityId: 'test-entity-1',
+                    testRelationPk: 'test-relations-test-entity-1-1',
+                  },
                 },
-                max: {
-                  relationName: 'foo1-test-relation-two',
-                  testEntityId: 'test-entity-1',
-                  testRelationPk: 'test-relations-test-entity-1-3',
-                },
-                min: {
-                  relationName: 'foo1-test-relation-one',
-                  testEntityId: 'test-entity-1',
-                  testRelationPk: 'test-relations-test-entity-1-1',
-                },
-              },
+              ],
             ],
             [
               entities[1],
-              {
-                count: {
-                  relationName: 3,
-                  testEntityId: 3,
-                  testRelationPk: 3,
+              [
+                {
+                  count: {
+                    relationName: 3,
+                    testEntityId: 3,
+                    testRelationPk: 3,
+                  },
+                  max: {
+                    relationName: 'foo2-test-relation-two',
+                    testEntityId: 'test-entity-2',
+                    testRelationPk: 'test-relations-test-entity-2-3',
+                  },
+                  min: {
+                    relationName: 'foo2-test-relation-one',
+                    testEntityId: 'test-entity-2',
+                    testRelationPk: 'test-relations-test-entity-2-1',
+                  },
                 },
-                max: {
-                  relationName: 'foo2-test-relation-two',
-                  testEntityId: 'test-entity-2',
-                  testRelationPk: 'test-relations-test-entity-2-3',
-                },
-                min: {
-                  relationName: 'foo2-test-relation-one',
-                  testEntityId: 'test-entity-2',
-                  testRelationPk: 'test-relations-test-entity-2-1',
-                },
-              },
+              ],
             ],
             [
               entities[2],
-              {
-                count: {
-                  relationName: 3,
-                  testEntityId: 3,
-                  testRelationPk: 3,
+              [
+                {
+                  count: {
+                    relationName: 3,
+                    testEntityId: 3,
+                    testRelationPk: 3,
+                  },
+                  max: {
+                    relationName: 'foo3-test-relation-two',
+                    testEntityId: 'test-entity-3',
+                    testRelationPk: 'test-relations-test-entity-3-3',
+                  },
+                  min: {
+                    relationName: 'foo3-test-relation-one',
+                    testEntityId: 'test-entity-3',
+                    testRelationPk: 'test-relations-test-entity-3-1',
+                  },
                 },
-                max: {
-                  relationName: 'foo3-test-relation-two',
-                  testEntityId: 'test-entity-3',
-                  testRelationPk: 'test-relations-test-entity-3-3',
+              ],
+            ],
+          ]),
+        );
+      });
+
+      it('aggregate and group for each entities relation', async () => {
+        const entities = TEST_ENTITIES.slice(0, 3);
+        const queryService = moduleRef.get(TestEntityService);
+        const queryResult = await queryService.aggregateRelations(
+          TestRelation,
+          'testRelations',
+          entities,
+          {},
+          {
+            groupBy: ['testEntityId'],
+            count: ['testRelationPk', 'relationName', 'testEntityId'],
+            min: ['testRelationPk', 'relationName', 'testEntityId'],
+            max: ['testRelationPk', 'relationName', 'testEntityId'],
+          },
+        );
+
+        expect(queryResult.size).toBe(3);
+        expect(queryResult).toEqual(
+          new Map([
+            [
+              entities[0],
+              [
+                {
+                  groupBy: {
+                    testEntityId: 'test-entity-1',
+                  },
+                  count: {
+                    relationName: 3,
+                    testEntityId: 3,
+                    testRelationPk: 3,
+                  },
+                  max: {
+                    relationName: 'foo1-test-relation-two',
+                    testEntityId: 'test-entity-1',
+                    testRelationPk: 'test-relations-test-entity-1-3',
+                  },
+                  min: {
+                    relationName: 'foo1-test-relation-one',
+                    testEntityId: 'test-entity-1',
+                    testRelationPk: 'test-relations-test-entity-1-1',
+                  },
                 },
-                min: {
-                  relationName: 'foo3-test-relation-one',
-                  testEntityId: 'test-entity-3',
-                  testRelationPk: 'test-relations-test-entity-3-1',
+              ],
+            ],
+            [
+              entities[1],
+              [
+                {
+                  groupBy: {
+                    testEntityId: 'test-entity-2',
+                  },
+                  count: {
+                    relationName: 3,
+                    testEntityId: 3,
+                    testRelationPk: 3,
+                  },
+                  max: {
+                    relationName: 'foo2-test-relation-two',
+                    testEntityId: 'test-entity-2',
+                    testRelationPk: 'test-relations-test-entity-2-3',
+                  },
+                  min: {
+                    relationName: 'foo2-test-relation-one',
+                    testEntityId: 'test-entity-2',
+                    testRelationPk: 'test-relations-test-entity-2-1',
+                  },
                 },
-              },
+              ],
+            ],
+            [
+              entities[2],
+              [
+                {
+                  groupBy: {
+                    testEntityId: 'test-entity-3',
+                  },
+                  count: {
+                    relationName: 3,
+                    testEntityId: 3,
+                    testRelationPk: 3,
+                  },
+                  max: {
+                    relationName: 'foo3-test-relation-two',
+                    testEntityId: 'test-entity-3',
+                    testRelationPk: 'test-relations-test-entity-3-3',
+                  },
+                  min: {
+                    relationName: 'foo3-test-relation-one',
+                    testEntityId: 'test-entity-3',
+                    testRelationPk: 'test-relations-test-entity-3-1',
+                  },
+                },
+              ],
             ],
           ]),
         );
@@ -619,63 +869,69 @@ describe('TypeOrmQueryService', (): void => {
           new Map([
             [
               entities[0],
-              {
-                count: {
-                  relationName: 2,
-                  testEntityId: 2,
-                  testRelationPk: 2,
+              [
+                {
+                  count: {
+                    relationName: 2,
+                    testEntityId: 2,
+                    testRelationPk: 2,
+                  },
+                  max: {
+                    relationName: 'foo1-test-relation-two',
+                    testEntityId: 'test-entity-1',
+                    testRelationPk: 'test-relations-test-entity-1-3',
+                  },
+                  min: {
+                    relationName: 'foo1-test-relation-three',
+                    testEntityId: 'test-entity-1',
+                    testRelationPk: 'test-relations-test-entity-1-2',
+                  },
                 },
-                max: {
-                  relationName: 'foo1-test-relation-two',
-                  testEntityId: 'test-entity-1',
-                  testRelationPk: 'test-relations-test-entity-1-3',
-                },
-                min: {
-                  relationName: 'foo1-test-relation-three',
-                  testEntityId: 'test-entity-1',
-                  testRelationPk: 'test-relations-test-entity-1-2',
-                },
-              },
+              ],
             ],
             [
               entities[1],
-              {
-                count: {
-                  relationName: 2,
-                  testEntityId: 2,
-                  testRelationPk: 2,
+              [
+                {
+                  count: {
+                    relationName: 2,
+                    testEntityId: 2,
+                    testRelationPk: 2,
+                  },
+                  max: {
+                    relationName: 'foo2-test-relation-two',
+                    testEntityId: 'test-entity-2',
+                    testRelationPk: 'test-relations-test-entity-2-3',
+                  },
+                  min: {
+                    relationName: 'foo2-test-relation-three',
+                    testEntityId: 'test-entity-2',
+                    testRelationPk: 'test-relations-test-entity-2-2',
+                  },
                 },
-                max: {
-                  relationName: 'foo2-test-relation-two',
-                  testEntityId: 'test-entity-2',
-                  testRelationPk: 'test-relations-test-entity-2-3',
-                },
-                min: {
-                  relationName: 'foo2-test-relation-three',
-                  testEntityId: 'test-entity-2',
-                  testRelationPk: 'test-relations-test-entity-2-2',
-                },
-              },
+              ],
             ],
             [
               entities[2],
-              {
-                count: {
-                  relationName: 2,
-                  testEntityId: 2,
-                  testRelationPk: 2,
+              [
+                {
+                  count: {
+                    relationName: 2,
+                    testEntityId: 2,
+                    testRelationPk: 2,
+                  },
+                  max: {
+                    relationName: 'foo3-test-relation-two',
+                    testEntityId: 'test-entity-3',
+                    testRelationPk: 'test-relations-test-entity-3-3',
+                  },
+                  min: {
+                    relationName: 'foo3-test-relation-three',
+                    testEntityId: 'test-entity-3',
+                    testRelationPk: 'test-relations-test-entity-3-2',
+                  },
                 },
-                max: {
-                  relationName: 'foo3-test-relation-two',
-                  testEntityId: 'test-entity-3',
-                  testRelationPk: 'test-relations-test-entity-3-3',
-                },
-                min: {
-                  relationName: 'foo3-test-relation-three',
-                  testEntityId: 'test-entity-3',
-                  testRelationPk: 'test-relations-test-entity-3-2',
-                },
-              },
+              ],
             ],
           ]),
         );
@@ -700,43 +956,47 @@ describe('TypeOrmQueryService', (): void => {
           new Map([
             [
               entities[0],
-              {
-                count: {
-                  relationName: 3,
-                  testEntityId: 3,
-                  testRelationPk: 3,
+              [
+                {
+                  count: {
+                    relationName: 3,
+                    testEntityId: 3,
+                    testRelationPk: 3,
+                  },
+                  max: {
+                    relationName: 'foo1-test-relation-two',
+                    testEntityId: 'test-entity-1',
+                    testRelationPk: 'test-relations-test-entity-1-3',
+                  },
+                  min: {
+                    relationName: 'foo1-test-relation-one',
+                    testEntityId: 'test-entity-1',
+                    testRelationPk: 'test-relations-test-entity-1-1',
+                  },
                 },
-                max: {
-                  relationName: 'foo1-test-relation-two',
-                  testEntityId: 'test-entity-1',
-                  testRelationPk: 'test-relations-test-entity-1-3',
-                },
-                min: {
-                  relationName: 'foo1-test-relation-one',
-                  testEntityId: 'test-entity-1',
-                  testRelationPk: 'test-relations-test-entity-1-1',
-                },
-              },
+              ],
             ],
             [
               { testEntityPk: 'does-not-exist' } as TestEntity,
-              {
-                count: {
-                  relationName: 0,
-                  testEntityId: 0,
-                  testRelationPk: 0,
+              [
+                {
+                  count: {
+                    relationName: 0,
+                    testEntityId: 0,
+                    testRelationPk: 0,
+                  },
+                  max: {
+                    relationName: null,
+                    testEntityId: null,
+                    testRelationPk: null,
+                  },
+                  min: {
+                    relationName: null,
+                    testEntityId: null,
+                    testRelationPk: null,
+                  },
                 },
-                max: {
-                  relationName: null,
-                  testEntityId: null,
-                  testRelationPk: null,
-                },
-                min: {
-                  relationName: null,
-                  testEntityId: null,
-                  testRelationPk: null,
-                },
-              },
+              ],
             ],
           ]),
         );

--- a/packages/query-typeorm/package.json
+++ b/packages/query-typeorm/package.json
@@ -22,7 +22,8 @@
     "lodash.filter": "^4.6.0",
     "lodash.omit": "^4.5.0",
     "tslib": "^2.1.0",
-    "uuid": "8.3.2"
+    "uuid": "^8.3.2",
+    "camel-case": "^4.1.2"
   },
   "peerDependencies": {
     "@nestjs/common": "^7.0.0",

--- a/packages/query-typeorm/src/query/filter-query.builder.ts
+++ b/packages/query-typeorm/src/query/filter-query.builder.ts
@@ -78,6 +78,7 @@ export class FilterQueryBuilder<Entity> {
     let qb = this.createQueryBuilder();
     qb = this.applyAggregate(qb, aggregate, qb.alias);
     qb = this.applyFilter(qb, query.filter, qb.alias);
+    qb = this.applyAggregateSorting(qb, aggregate.groupBy, qb.alias);
     qb = this.applyGroupBy(qb, aggregate.groupBy, qb.alias);
     return qb;
   }
@@ -179,6 +180,16 @@ export class FilterQueryBuilder<Entity> {
     return groupBy.reduce((prevQb, group) => {
       const col = alias ? `${alias}.${group as string}` : `${group as string}`;
       return prevQb.addGroupBy(col);
+    }, qb);
+  }
+
+  applyAggregateSorting<T extends Sortable<Entity>>(qb: T, groupBy?: (keyof Entity)[], alias?: string): T {
+    if (!groupBy) {
+      return qb;
+    }
+    return groupBy.reduce((prevQb, field) => {
+      const col = alias ? `${alias}.${field as string}` : `${field as string}`;
+      return prevQb.addOrderBy(col, 'ASC');
     }, qb);
   }
 

--- a/packages/query-typeorm/src/query/filter-query.builder.ts
+++ b/packages/query-typeorm/src/query/filter-query.builder.ts
@@ -20,6 +20,10 @@ interface Sortable<Entity> extends QueryBuilder<Entity> {
   addOrderBy(sort: string, order?: 'ASC' | 'DESC', nulls?: 'NULLS FIRST' | 'NULLS LAST'): this;
 }
 
+interface Groupable<Entity> extends QueryBuilder<Entity> {
+  addGroupBy(groupBy: string): this;
+}
+
 /**
  * @internal
  *
@@ -74,6 +78,7 @@ export class FilterQueryBuilder<Entity> {
     let qb = this.createQueryBuilder();
     qb = this.applyAggregate(qb, aggregate, qb.alias);
     qb = this.applyFilter(qb, query.filter, qb.alias);
+    qb = this.applyGroupBy(qb, aggregate.groupBy, qb.alias);
     return qb;
   }
 
@@ -164,6 +169,16 @@ export class FilterQueryBuilder<Entity> {
     return sorts.reduce((prevQb, { field, direction, nulls }) => {
       const col = alias ? `${alias}.${field as string}` : `${field as string}`;
       return prevQb.addOrderBy(col, direction, nulls);
+    }, qb);
+  }
+
+  applyGroupBy<T extends Groupable<Entity>>(qb: T, groupBy?: (keyof Entity)[], alias?: string): T {
+    if (!groupBy) {
+      return qb;
+    }
+    return groupBy.reduce((prevQb, group) => {
+      const col = alias ? `${alias}.${group as string}` : `${group as string}`;
+      return prevQb.addGroupBy(col);
     }, qb);
   }
 

--- a/packages/query-typeorm/src/query/relation-query.builder.ts
+++ b/packages/query-typeorm/src/query/relation-query.builder.ts
@@ -96,7 +96,7 @@ export class RelationQueryBuilder<Entity, Relation> {
     query: Query<Relation>,
     aggregateQuery: AggregateQuery<Relation>,
   ): SelectQueryBuilder<EntityIndexRelation<Record<string, unknown>>> {
-    const selects = [...AggregateBuilder.getAggregateAliases(aggregateQuery), this.entityIndexColName].map((c) =>
+    const selects = [...AggregateBuilder.getAggregateSelects(aggregateQuery), this.entityIndexColName].map((c) =>
       this.escapeName(c),
     );
     const unionFragment = this.createUnionAggregateSubQuery(entities, query, aggregateQuery);
@@ -114,7 +114,13 @@ export class RelationQueryBuilder<Entity, Relation> {
   ): SelectQueryBuilder<Relation> {
     let relationBuilder = this.createRelationQueryBuilder(entity);
     relationBuilder = this.filterQueryBuilder.applyAggregate(relationBuilder, aggregateQuery, relationBuilder.alias);
-    return this.filterQueryBuilder.applyFilter(relationBuilder, query.filter, relationBuilder.alias);
+    relationBuilder = this.filterQueryBuilder.applyFilter(relationBuilder, query.filter, relationBuilder.alias);
+    relationBuilder = this.filterQueryBuilder.applyGroupBy(
+      relationBuilder,
+      aggregateQuery.groupBy,
+      relationBuilder.alias,
+    );
+    return relationBuilder;
   }
 
   private createUnionAggregateSubQuery(

--- a/packages/query-typeorm/src/query/relation-query.builder.ts
+++ b/packages/query-typeorm/src/query/relation-query.builder.ts
@@ -115,6 +115,11 @@ export class RelationQueryBuilder<Entity, Relation> {
     let relationBuilder = this.createRelationQueryBuilder(entity);
     relationBuilder = this.filterQueryBuilder.applyAggregate(relationBuilder, aggregateQuery, relationBuilder.alias);
     relationBuilder = this.filterQueryBuilder.applyFilter(relationBuilder, query.filter, relationBuilder.alias);
+    relationBuilder = this.filterQueryBuilder.applyAggregateSorting(
+      relationBuilder,
+      aggregateQuery.groupBy,
+      relationBuilder.alias,
+    );
     relationBuilder = this.filterQueryBuilder.applyGroupBy(
       relationBuilder,
       aggregateQuery.groupBy,

--- a/packages/query-typeorm/src/services/typeorm-query.service.ts
+++ b/packages/query-typeorm/src/services/typeorm-query.service.ts
@@ -76,9 +76,9 @@ export class TypeOrmQueryService<Entity>
     return this.filterQueryBuilder.select(query).getMany();
   }
 
-  async aggregate(filter: Filter<Entity>, aggregate: AggregateQuery<Entity>): Promise<AggregateResponse<Entity>> {
+  async aggregate(filter: Filter<Entity>, aggregate: AggregateQuery<Entity>): Promise<AggregateResponse<Entity>[]> {
     return AggregateBuilder.asyncConvertToAggregateResponse(
-      this.filterQueryBuilder.aggregate({ filter }, aggregate).getRawOne<Record<string, unknown>>(),
+      this.filterQueryBuilder.aggregate({ filter }, aggregate).getRawMany<Record<string, unknown>>(),
     );
   }
 


### PR DESCRIPTION
## Aggregate Queries Return Arrays

In versions prior to `v0.24.0` aggregate queries returned a single response with just the aggregated values. In `v0.25.0` we have introduced a new `groupBy` option that requires aggregates to return arrays.

When using aggregates without the groupBy the response will always contain a single record with your aggregated
values. If you specify a `groupBy` you will get a response with a distinct group and the corresponding aggregated
values.

Given the following query

```graphql
{
  todoItemAggregate {
    count {
      id
    }
    sum {
      id
    }
    avg {
      id
    }
    min {
      id
      title
      created
    }
    max {
      id
      title
      created
    }
  }
}
```

### Old

The old response would look like

```json
{
  "data": {
    "todoItemAggregate": {
      "count": {
        "id": 5
      },
      "sum": {
        "id": 15
      },
      "avg": {
        "id": 3
      },
      "min": {
        "id": "1",
        "title": "Add Todo Item Resolver",
        "created": "2021-03-29T06:51:26.061Z"
      },
      "max": {
        "id": "5",
        "title": "How to create item With Sub Tasks",
        "created": "2021-03-29T06:51:26.061Z"
      }
    }
  }
}
```

### New
The new response will look like
```json
{
  "data": {
    "todoItemAggregate": [
      {
        "count": {
          "id": 5
        },
        "sum": {
          "id": 15
        },
        "avg": {
          "id": 3
        },
        "min": {
          "id": "1",
          "title": "Add Todo Item Resolver",
          "created": "2021-03-29T06:51:26.061Z"
        },
        "max": {
          "id": "5",
          "title": "How to create item With Sub Tasks",
          "created": "2021-03-29T06:51:26.061Z"
        }
      }
    ]
  }
}
```

## New Aggregate GroupBy

The new response format really shines when using the `groupBy` query

Given the following aggregate grouping on `completed`

```graphql {3-5}
{
  todoItemAggregate {
    groupBy {
      completed
    }
    count {
      id
    }
    sum {
      id
    }
    avg {
      id
    }
    min {
      id
      title
      created
    }
    max {
      id
      title
      created
    }
  }
}
```

You'll get the following response with record for each distinct group

```json
{
  "data": {
    "todoItemAggregate": [
      {
        "groupBy": {
          "completed": false
        },
        "count": {
          "id": 4
        },
        "sum": {
          "id": 14
        },
        "avg": {
          "id": 3.5
        },
        "min": {
          "id": "2",
          "title": "Add Todo Item Resolver",
          "created": "2021-03-29T06:51:26.061Z"
        },
        "max": {
          "id": "5",
          "title": "How to create item With Sub Tasks",
          "created": "2021-03-29T06:51:26.061Z"
        }
      },
      {
        "groupBy": {
          "completed": true
        },
        "count": {
          "id": 1
        },
        "sum": {
          "id": 1
        },
        "avg": {
          "id": 1
        },
        "min": {
          "id": "1",
          "title": "Create Nest App",
          "created": "2021-03-29T06:51:26.061Z"
        },
        "max": {
          "id": "1",
          "title": "Create Nest App",
          "created": "2021-03-29T06:51:26.061Z"
        }
      }
    ]
  }
}
```