### PR TITLE
feat(graphql,auth,#1026): Pass operation name to authorizer

### DIFF
--- a/documentation/docs/graphql/authorization.mdx
+++ b/documentation/docs/graphql/authorization.mdx
@@ -397,7 +397,7 @@ If you are extending the `CRUDResolver` directly be sure to [register your DTOs 
 Sometimes it might be necessary to perform different authorization based on the kind of operation an user wants to execute.
 E.g. some users could be allowed to read all todo items but only update/delete their own.
 
-In this case we can make use of the second parameter of the `authorize` function in our custom `Authorizer` or the one passed to the `@Authorizer` decorator which gets passed the name of the operation that should be authorized:
+In this case we can make use of the second parameter of the `authorize` function in our custom `Authorizer` or the one passed to the `@Authorizer` decorator which gets passed additional `AuthorizationContext` such as the name of the operation that should be authorized:
 
 ```ts title='sub-task/sub-task.authorizer.ts'
 import { Injectable } from '@nestjs/common';
@@ -408,7 +408,9 @@ import { SubTaskDTO } from './dto/sub-task.dto';
 
 @Injectable()
 export class SubTaskAuthorizer implements Authorizer<SubTaskDTO> {
-  authorize(context: UserContext, operationName?: string): Promise<Filter<SubTaskDTO>> {
+  authorize(context: UserContext, authorizationContext?: AuthorizationContext): Promise<Filter<SubTaskDTO>> {
+    const operationName = authorizationContext?.operationName;
+
     if (
       operationName.startsWith('query') ||
       operationName.startsWith('find') ||
@@ -429,7 +431,7 @@ export class SubTaskAuthorizer implements Authorizer<SubTaskDTO> {
 }
 ```
 
-The operation name is the name of the method that makes use of the `@AuthorizerFilter()` or the argument passed to this decorator (`@AuthorizerFilter('customMethodName')`).
+The `operationName` is the name of the method that makes use of the `@AuthorizerFilter()` or the argument passed to this decorator (`@AuthorizerFilter('customMethodName')`).
 The names of the generated CRUD resolver methods are similar to the ones of the [QueryService](../concepts/services.mdx):
 
 - `query`

--- a/documentation/docs/graphql/authorization.mdx
+++ b/documentation/docs/graphql/authorization.mdx
@@ -409,13 +409,7 @@ import { SubTaskDTO } from './dto/sub-task.dto';
 @Injectable()
 export class SubTaskAuthorizer implements Authorizer<SubTaskDTO> {
   authorize(context: UserContext, authorizationContext?: AuthorizationContext): Promise<Filter<SubTaskDTO>> {
-    const operationName = authorizationContext?.operationName;
-
-    if (
-      operationName.startsWith('query') ||
-      operationName.startsWith('find') ||
-      operationName.startsWith('aggregate')
-    ) {
+    if (authorizationContext?.readonly) {
       return Promise.resolve({});
     }
 
@@ -430,6 +424,39 @@ export class SubTaskAuthorizer implements Authorizer<SubTaskDTO> {
   }
 }
 ```
+
+The `AuthorizationContext` has the following shape:
+
+```ts title='authorizer.ts'
+interface AuthorizationContext {
+  /** The name of the method that uses the @AuthorizeFilter decorator */
+  operationName: string;
+
+  /** The group this operation belongs to */
+  operationGroup: 'read' | 'aggregate' | 'create' | 'update' | 'delete';
+
+  /** If the operation does not modify any entities */
+  readonly: boolean;
+
+  /** If the operation can affect multiple entities */
+  many: boolean;
+}
+```
+
+This context is automatially created for you when using the built-in resolvers.
+If you authorize custom methods by using the `@AuthorizerFilter()`, you have three options:
+
+- Pass your own `AuthorizationContext` as argument to the decorator:
+  ```ts
+  @AuthorizerFilter({
+    operationName: 'completedTodoItems',
+    operationGroup: 'read',
+    readonly: true,
+    many: true
+  })
+  ```
+- Pass a custom operation name as argument and let the context be inferred from the name (the nae should follow the conventions below): `@AuthorizerFilter('queryCompletedTodoItems')`.
+- Don't pass a custom name and let the decorator use the name of the decorated method: `@AuthorizerFilter()`
 
 The `operationName` is the name of the method that makes use of the `@AuthorizerFilter()` or the argument passed to this decorator (`@AuthorizerFilter('customMethodName')`).
 The names of the generated CRUD resolver methods are similar to the ones of the [QueryService](../concepts/services.mdx):

--- a/documentation/docs/graphql/authorization.mdx
+++ b/documentation/docs/graphql/authorization.mdx
@@ -428,12 +428,20 @@ export class SubTaskAuthorizer implements Authorizer<SubTaskDTO> {
 The `AuthorizationContext` has the following shape:
 
 ```ts title='authorizer.ts'
+export enum OperationGroup {
+  READ = 'read',
+  AGGREGATE = 'aggregate',
+  CREATE = 'create',
+  UPDATE = 'update',
+  DELETE = 'delete',
+}
+
 interface AuthorizationContext {
   /** The name of the method that uses the @AuthorizeFilter decorator */
   operationName: string;
 
   /** The group this operation belongs to */
-  operationGroup: 'read' | 'aggregate' | 'create' | 'update' | 'delete';
+  operationGroup: OperationGroup;
 
   /** If the operation does not modify any entities */
   readonly: boolean;
@@ -444,26 +452,27 @@ interface AuthorizationContext {
 ```
 
 This context is automatially created for you when using the built-in resolvers.
-If you authorize custom methods by using the `@AuthorizerFilter()`, you have three options:
+If you authorize custom methods by using the `@AuthorizerFilter()`, you should pass the context as argument to the decorator:
 
-- Pass your own `AuthorizationContext` as argument to the decorator:
-  ```ts
-  @AuthorizerFilter({
-    operationName: 'completedTodoItems',
-    operationGroup: 'read',
-    readonly: true,
-    many: true
-  })
-  ```
-- Pass a custom operation name as argument and let the context be inferred from the name (the nae should follow the conventions below): `@AuthorizerFilter('queryCompletedTodoItems')`.
-- Don't pass a custom name and let the decorator use the name of the decorated method: `@AuthorizerFilter()`
+```ts
+@AuthorizerFilter({
+  operationName: 'completedTodoItems',
+  operationGroup: OperationGroup.READ,
+  readonly: true,
+  many: true
+})
+```
 
-The `operationName` is the name of the method that makes use of the `@AuthorizerFilter()` or the argument passed to this decorator (`@AuthorizerFilter('customMethodName')`).
-The names of the generated CRUD resolver methods are similar to the ones of the [QueryService](../concepts/services.mdx):
+You can leave out the `operationName` to let the context use the name of the decorated Method.
+If you leave out the `readonly` property, it's inferred from the `operationGroup`.
 
-- `query`
+The `operationNames` of the generated CRUD resolver methods are similar to the ones of the [QueryService](../concepts/services.mdx):
+
+- `queryMany`
 - `findById`
 - `aggregate`
+- `createOne`
+- `createMany`
 - `updateOne`
 - `updateMany`
 - `deleteOne`
@@ -474,8 +483,10 @@ The names of the generated CRUD resolver methods are similar to the ones of the 
 - `query{PluralRelationName}` (e.g. querySubTasks)
 - `find{SingularRelationName}` (e.g. findTodoItem)
 - `aggregate{PluralRelationName}` (e.g. aggregateSubTasks)
-- `remove{RelationName}from{SingularParentName}` (e.g. removeSubTaskFromTodoItem)
-- `set{RelationName}On{SingularParentName}` (e.g. setSubTaskOnTodoItem)
+- `remove{SingularRelationName}from{SingularParentName}` (e.g. removeSubTaskFromTodoItem)
+- `remove{PluralRelationName}from{SingularParentName}` (e.g. removeSubTasksFromTodoItem)
+- `set{SingularRelationName}On{SingularParentName}` (e.g. setSubTaskOnTodoItem)
+- `add{PluralRelationName}On{SingularParentName}` (e.g. addSubTasksOnTodoItem)
 
 ## Complete Example
 

--- a/documentation/docs/graphql/authorization.mdx
+++ b/documentation/docs/graphql/authorization.mdx
@@ -13,10 +13,10 @@ The following section assumes you are familiar with [authentication in nestjs](h
 
 The `nestjs-query` graphql package exposes decorators and options to allow the following
 
-* Additional filtering for objects based on the graphql context.
-* Filtering relations based on the graphql context.
-* Low level authorization service support when your authorizer needs to use other services or additional information
-that is not in the graphql context.
+- Additional filtering for objects based on the graphql context.
+- Filtering relations based on the graphql context.
+- Low level authorization service support when your authorizer needs to use other services or additional information
+  that is not in the graphql context.
 
 :::info
 If you are looking to modify incoming requests based on the context, take a look at the [hooks documentation](./hooks.mdx)
@@ -31,11 +31,10 @@ Authorization is invoked as the last step before calling the `QueryService`.
 All examples assume you have a guard that adds a `user` to the req on the context.
 
 ```ts
-
 type AuthenticatedUser = {
   id: number;
   username: string;
-}
+};
 
 type UserContext = {
   req: {
@@ -85,19 +84,21 @@ The `@nestjs-query/query-graphql` package includes a `@Authorize` decorator that
 criteria to authorize an incoming request.
 
 The `@Authorize` decorator accepts the following types.
-* An `object` that has an `authorize` method that returns a Filter for the DTO.
-* An instance of an `Authorizer` that implements the `authorize` and `authorizeRelation` methods.
-* An `Authorizer` class reference that implements the `Authorizer` interface. The `Authorizer` class will be
-instantiated using the `nestjs`'s dependency injection.
+
+- An `object` that has an `authorize` method that returns a Filter for the DTO.
+- An instance of an `Authorizer` that implements the `authorize` and `authorizeRelation` methods.
+- An `Authorizer` class reference that implements the `Authorizer` interface. The `Authorizer` class will be
+  instantiated using the `nestjs`'s dependency injection.
 
 The `@Authorize` decorator does not return an unauthorized error instead the following will occur:
- * `queryMany` results will not include any DTOs that do not match the filter criteria.
- * `findOne` will return a not found for a DTO that is cannot be found for the `id` and auth filter.
- * `updateOne` will return a not found error if the DTO to update cannot be found for the `id` and auth filter.
- * `updateMany` will exclude any records that do not match the user provided filter and the auth filter from being
- updated.
- * `deleteOne` will return a not found error if the DTO to delete cannot be found for the `id` and auth filter.
- * `deleteMany` will exclude any records that do not match the user provided filter and the auth filter from being
+
+- `queryMany` results will not include any DTOs that do not match the filter criteria.
+- `findOne` will return a not found for a DTO that is cannot be found for the `id` and auth filter.
+- `updateOne` will return a not found error if the DTO to update cannot be found for the `id` and auth filter.
+- `updateMany` will exclude any records that do not match the user provided filter and the auth filter from being
+  updated.
+- `deleteOne` will return a not found error if the DTO to delete cannot be found for the `id` and auth filter.
+- `deleteMany` will exclude any records that do not match the user provided filter and the auth filter from being
   deleted.
 
 :::note
@@ -155,7 +156,6 @@ export class TodoItemDTO {
   @FilterableField()
   ownerId!: number;
 }
-
 ```
 
 :::note
@@ -169,11 +169,12 @@ By default when relations are queried any additional filters defined using the `
 DTO will also be included.
 
 When mutating relations
-* If the DTO that is having a relation(s) added or removed cannot be found for the `id` and
-auth filter a not found error will be returned.
-* When adding or removing a single relation if the relation cannot be found for the `id` and auth filter a not found
-error will be returned.
-* When adding or removing multiple relations if all relations cannot be found a not found error will be throw.
+
+- If the DTO that is having a relation(s) added or removed cannot be found for the `id` and
+  auth filter a not found error will be returned.
+- When adding or removing a single relation if the relation cannot be found for the `id` and auth filter a not found
+  error will be returned.
+- When adding or removing multiple relations if all relations cannot be found a not found error will be throw.
 
 For example given the following `SubTaskDTO` definition whenever the `subTasks` connection is queried through a
 `todoItem`, only `subTasks` that belong to the user will be returned.
@@ -240,13 +241,13 @@ For example you could define the subtasks with the `auth` option, only allowing 
 ### Custom Authorizer
 
 When you need more control over authorization you can create a custom `Authorizer`. You may want to use a custom
- `Authorizer` if you need to use additional services to do authorization for a DTO.
+`Authorizer` if you need to use additional services to do authorization for a DTO.
 
 The `Authorizer` interface requires two methods to be implemented
 
-* `authorize` - Should return a filter that should be used for all queries and mutations for the DTO.
-* `authorizeRelation` - Should return a filter for the relation that will be used when querying the relation or
-adding/removing relations to/from the DTO.
+- `authorize` - Should return a filter that should be used for all queries and mutations for the DTO.
+- `authorizeRelation` - Should return a filter for the relation that will be used when querying the relation or
+  adding/removing relations to/from the DTO.
 
 In this example we'll create a simple authorizer for `SubTasks`. You can use this as a base to create a more complex
 authorizers that depends on other services.
@@ -324,8 +325,9 @@ The easiest way to leverage `Authorizers` in a custom resolver is to use the `Au
 `AuthorizerFilter` param decorator.
 
 In this example there are two important additions:
+
 1. The `AuthorizerInterceptor` is added to the `TodoItemResolver` as an interceptor, this interceptor will add the
- authorizer to the context so it can be used down stream
+   authorizer to the context so it can be used down stream
 2. The `AuthorizerFilter` param decorator uses the authorizer added by the interceptor to create an authorizer filter.
 
 ```ts title="todo-item/todo-item.resolver.ts" {9,17}
@@ -379,17 +381,72 @@ import { TodoItemEntity } from './todo-item.entity';
 export class TodoItemResolver extends CRUDResolver(TodoItemDTO) {
   constructor(
     @InjectQueryService(TodoItemEntity) readonly service: QueryService<TodoItemEntity>,
-    @InjectAuthorizer(TodoItemDTO) readonly authorizer: Authorizer<TodoItemDTO>
+    @InjectAuthorizer(TodoItemDTO) readonly authorizer: Authorizer<TodoItemDTO>,
   ) {
     super(service);
   }
 }
-
 ```
 
 :::important
 If you are extending the `CRUDResolver` directly be sure to [register your DTOs with the `NestjsQueryGraphQLModule`](./resolvers.mdx#crudresolver)
 :::
+
+## Authorize depending on operation
+
+Sometimes it might be necessary to perform different authorization based on the kind of operation an user wants to execute.
+E.g. some users could be allowed to read all todo items but only update/delete their own.
+
+In this case we can make use of the second parameter of the `authorize` function in our custom `Authorizer` or the one passed to the `@Authorizer` decorator which gets passed the name of the operation that should be authorized:
+
+```ts title='sub-task/sub-task.authorizer.ts'
+import { Injectable } from '@nestjs/common';
+import { Authorizer } from '@nestjs-query/query-graphql';
+import { Filter } from '@nestjs-query/core';
+import { UserContext } from '../auth/auth.interfaces';
+import { SubTaskDTO } from './dto/sub-task.dto';
+
+@Injectable()
+export class SubTaskAuthorizer implements Authorizer<SubTaskDTO> {
+  authorize(context: UserContext, operationName?: string): Promise<Filter<SubTaskDTO>> {
+    if (
+      operationName.startsWith('query') ||
+      operationName.startsWith('find') ||
+      operationName.startsWith('aggregate')
+    ) {
+      return Promise.resolve({});
+    }
+
+    return Promise.resolve({ ownerId: { eq: context.req.user.id } });
+  }
+
+  authorizeRelation(relationName: string, context: UserContext): Promise<Filter<unknown>> {
+    if (relationName === 'todoItem') {
+      return Promise.resolve({ ownerId: { eq: context.req.user.id } });
+    }
+    return Promise.resolve({});
+  }
+}
+```
+
+The operation name is the name of the method that makes use of the `@AuthorizerFilter()` or the argument passed to this decorator (`@AuthorizerFilter('customMethodName')`).
+The names of the generated CRUD resolver methods are similar to the ones of the [QueryService](../concepts/services.mdx):
+
+- `query`
+- `findById`
+- `aggregate`
+- `updateOne`
+- `updateMany`
+- `deleteOne`
+- `deleteMany`
+
+**Relations**
+
+- `query{PluralRelationName}` (e.g. querySubTasks)
+- `find{SingularRelationName}` (e.g. findTodoItem)
+- `aggregate{PluralRelationName}` (e.g. aggregateSubTasks)
+- `remove{RelationName}from{SingularParentName}` (e.g. removeSubTaskFromTodoItem)
+- `set{RelationName}On{SingularParentName}` (e.g. setSubTaskOnTodoItem)
 
 ## Complete Example
 

--- a/examples/auth/e2e/todo-item.resolver.spec.ts
+++ b/examples/auth/e2e/todo-item.resolver.spec.ts
@@ -498,6 +498,28 @@ describe('TodoItemResolver (auth - e2e)', () => {
           ]);
         }));
 
+    it(`should throw an error if AuthorizationContext was not setup`, () =>
+      request(app.getHttpServer())
+        .post('/graphql')
+        .auth(user3JwtToken, { type: 'bearer' })
+        .send({
+          operationName: null,
+          variables: {},
+          query: `{
+              failingTodoItems {
+              ${pageInfoField}
+              ${edgeNodes(todoItemFields)}
+              totalCount
+            }
+          }`,
+        })
+        .expect(200)
+        .then(({ body }) =>
+          expect(body.errors[0].message).toBe(
+            'No AuthorizationContext available for method failingTodoItems! Make sure that you provide an AuthorizationContext to your custom methods as argument of the @AuthorizerFilter decorator.',
+          ),
+        ));
+
     describe('paging', () => {
       it(`should allow paging with the 'first' field`, () =>
         request(app.getHttpServer())

--- a/examples/auth/src/sub-task/sub-task.authorizer.ts
+++ b/examples/auth/src/sub-task/sub-task.authorizer.ts
@@ -5,13 +5,7 @@ import { SubTaskDTO } from './dto/sub-task.dto';
 
 export class SubTaskAuthorizer implements Authorizer<SubTaskDTO> {
   authorize(context: UserContext, authorizationContext?: AuthorizationContext): Promise<Filter<SubTaskDTO>> {
-    const operationName = authorizationContext?.operationName;
-    if (
-      context.req.user.username === 'nestjs-query-3' &&
-      (operationName?.startsWith('query') ||
-        operationName?.startsWith('find') ||
-        operationName?.startsWith('aggregate'))
-    ) {
+    if (context.req.user.username === 'nestjs-query-3' && authorizationContext?.readonly) {
       return Promise.resolve({});
     }
     return Promise.resolve({ ownerId: { eq: context.req.user.id } });

--- a/examples/auth/src/sub-task/sub-task.authorizer.ts
+++ b/examples/auth/src/sub-task/sub-task.authorizer.ts
@@ -4,7 +4,15 @@ import { UserContext } from '../auth/auth.interfaces';
 import { SubTaskDTO } from './dto/sub-task.dto';
 
 export class SubTaskAuthorizer implements Authorizer<SubTaskDTO> {
-  authorize(context: UserContext): Promise<Filter<SubTaskDTO>> {
+  authorize(context: UserContext, operationName?: string): Promise<Filter<SubTaskDTO>> {
+    if (
+      context.req.user.username === 'nestjs-query-3' &&
+      (operationName?.startsWith('query') ||
+        operationName?.startsWith('find') ||
+        operationName?.startsWith('aggregate'))
+    ) {
+      return Promise.resolve({});
+    }
     return Promise.resolve({ ownerId: { eq: context.req.user.id } });
   }
 

--- a/examples/auth/src/sub-task/sub-task.authorizer.ts
+++ b/examples/auth/src/sub-task/sub-task.authorizer.ts
@@ -1,10 +1,11 @@
-import { Authorizer } from '@nestjs-query/query-graphql';
+import { Authorizer, AuthorizationContext } from '@nestjs-query/query-graphql';
 import { Filter } from '@nestjs-query/core';
 import { UserContext } from '../auth/auth.interfaces';
 import { SubTaskDTO } from './dto/sub-task.dto';
 
 export class SubTaskAuthorizer implements Authorizer<SubTaskDTO> {
-  authorize(context: UserContext, operationName?: string): Promise<Filter<SubTaskDTO>> {
+  authorize(context: UserContext, authorizationContext?: AuthorizationContext): Promise<Filter<SubTaskDTO>> {
+    const operationName = authorizationContext?.operationName;
     if (
       context.req.user.username === 'nestjs-query-3' &&
       (operationName?.startsWith('query') ||

--- a/examples/auth/src/todo-item/dto/todo-item.dto.ts
+++ b/examples/auth/src/todo-item/dto/todo-item.dto.ts
@@ -13,7 +13,19 @@ import { UserContext } from '../../auth/auth.interfaces';
 
 @ObjectType('TodoItem')
 @QueryOptions({ enableTotalCount: true })
-@Authorize({ authorize: (context: UserContext) => ({ ownerId: { eq: context.req.user.id } }) })
+@Authorize({
+  authorize: (context: UserContext, operationName?: string) => {
+    if (
+      context.req.user.username === 'nestjs-query-3' &&
+      (operationName?.startsWith('query') ||
+        operationName?.startsWith('find') ||
+        operationName?.startsWith('aggregate'))
+    ) {
+      return {};
+    }
+    return { ownerId: { eq: context.req.user.id } };
+  },
+})
 @Relation('owner', () => UserDTO, { disableRemove: true, disableUpdate: true })
 @FilterableCursorConnection('subTasks', () => SubTaskDTO, { disableRemove: true })
 @FilterableCursorConnection('tags', () => TagDTO)

--- a/examples/auth/src/todo-item/dto/todo-item.dto.ts
+++ b/examples/auth/src/todo-item/dto/todo-item.dto.ts
@@ -4,6 +4,7 @@ import {
   Relation,
   FilterableCursorConnection,
   QueryOptions,
+  AuthorizationContext,
 } from '@nestjs-query/query-graphql';
 import { ObjectType, ID, GraphQLISODateTime, Field } from '@nestjs/graphql';
 import { SubTaskDTO } from '../../sub-task/dto/sub-task.dto';
@@ -14,7 +15,8 @@ import { UserContext } from '../../auth/auth.interfaces';
 @ObjectType('TodoItem')
 @QueryOptions({ enableTotalCount: true })
 @Authorize({
-  authorize: (context: UserContext, operationName?: string) => {
+  authorize: (context: UserContext, authorizationContext?: AuthorizationContext) => {
+    const operationName = authorizationContext?.operationName;
     if (
       context.req.user.username === 'nestjs-query-3' &&
       (operationName?.startsWith('query') ||

--- a/examples/auth/src/todo-item/dto/todo-item.dto.ts
+++ b/examples/auth/src/todo-item/dto/todo-item.dto.ts
@@ -7,6 +7,7 @@ import {
   AuthorizationContext,
 } from '@nestjs-query/query-graphql';
 import { ObjectType, ID, GraphQLISODateTime, Field } from '@nestjs/graphql';
+import { UnauthorizedException } from '@nestjs/common';
 import { SubTaskDTO } from '../../sub-task/dto/sub-task.dto';
 import { TagDTO } from '../../tag/dto/tag.dto';
 import { UserDTO } from '../../user/user.dto';
@@ -21,6 +22,9 @@ import { UserContext } from '../../auth/auth.interfaces';
       (authorizationContext?.operationGroup === 'read' || authorizationContext?.operationGroup === 'aggregate')
     ) {
       return {};
+    }
+    if (context.req.user.username === 'nestjs-query-3' && authorizationContext?.operationGroup === 'create') {
+      throw new UnauthorizedException();
     }
     return { ownerId: { eq: context.req.user.id } };
   },

--- a/examples/auth/src/todo-item/dto/todo-item.dto.ts
+++ b/examples/auth/src/todo-item/dto/todo-item.dto.ts
@@ -16,12 +16,9 @@ import { UserContext } from '../../auth/auth.interfaces';
 @QueryOptions({ enableTotalCount: true })
 @Authorize({
   authorize: (context: UserContext, authorizationContext?: AuthorizationContext) => {
-    const operationName = authorizationContext?.operationName;
     if (
       context.req.user.username === 'nestjs-query-3' &&
-      (operationName?.startsWith('query') ||
-        operationName?.startsWith('find') ||
-        operationName?.startsWith('aggregate'))
+      (authorizationContext?.operationGroup === 'read' || authorizationContext?.operationGroup === 'aggregate')
     ) {
       return {};
     }

--- a/examples/auth/src/todo-item/todo-item.resolver.ts
+++ b/examples/auth/src/todo-item/todo-item.resolver.ts
@@ -54,4 +54,20 @@ export class TodoItemResolver {
       (q) => this.service.count(q),
     );
   }
+
+  @Query(() => TodoItemConnection)
+  async failingTodoItems(
+    @Args() query: TodoItemQuery,
+    @AuthorizerFilter() // Intentionally left out argument to test error
+    authFilter: Filter<TodoItemDTO>,
+  ): Promise<ConnectionType<TodoItemDTO>> {
+    // add the completed filter the user provided filter
+    const filter: Filter<TodoItemDTO> = mergeFilter(query.filter ?? {}, { completed: { is: false } });
+    const uncompletedQuery = mergeQuery(query, { filter: mergeFilter(filter, authFilter) });
+    return TodoItemConnection.createFromPromise(
+      (q) => this.service.query(q),
+      uncompletedQuery,
+      (q) => this.service.count(q),
+    );
+  }
 }

--- a/examples/auth/src/todo-item/todo-item.resolver.ts
+++ b/examples/auth/src/todo-item/todo-item.resolver.ts
@@ -1,5 +1,10 @@
 import { Filter, InjectAssemblerQueryService, mergeFilter, mergeQuery, QueryService } from '@nestjs-query/core';
-import { AuthorizerInterceptor, AuthorizerFilter, ConnectionType } from '@nestjs-query/query-graphql';
+import {
+  AuthorizerInterceptor,
+  AuthorizerFilter,
+  ConnectionType,
+  AuthorizationOperationGroup,
+} from '@nestjs-query/query-graphql';
 import { Args, Query, Resolver } from '@nestjs/graphql';
 import { UseGuards, UseInterceptors } from '@nestjs/common';
 import { TodoItemDTO } from './dto/todo-item.dto';
@@ -17,7 +22,11 @@ export class TodoItemResolver {
   @Query(() => TodoItemConnection)
   async completedTodoItems(
     @Args() query: TodoItemQuery,
-    @AuthorizerFilter('queryCompletedTodoItems') authFilter: Filter<TodoItemDTO>,
+    @AuthorizerFilter({
+      operationGroup: AuthorizationOperationGroup.READ,
+      many: true,
+    })
+    authFilter: Filter<TodoItemDTO>,
   ): Promise<ConnectionType<TodoItemDTO>> {
     // add the completed filter the user provided filter
     const filter: Filter<TodoItemDTO> = mergeFilter(query.filter ?? {}, { completed: { is: true } });
@@ -34,9 +43,7 @@ export class TodoItemResolver {
   async uncompletedTodoItems(
     @Args() query: TodoItemQuery,
     @AuthorizerFilter({
-      operationName: 'queryUncompletedTodoItems',
-      operationGroup: 'read',
-      readonly: true,
+      operationGroup: AuthorizationOperationGroup.READ,
       many: true,
     })
     authFilter: Filter<TodoItemDTO>,

--- a/examples/auth/src/todo-item/todo-item.resolver.ts
+++ b/examples/auth/src/todo-item/todo-item.resolver.ts
@@ -1,10 +1,5 @@
 import { Filter, InjectAssemblerQueryService, mergeFilter, mergeQuery, QueryService } from '@nestjs-query/core';
-import {
-  AuthorizerInterceptor,
-  AuthorizerFilter,
-  ConnectionType,
-  AuthorizationOperationGroup,
-} from '@nestjs-query/query-graphql';
+import { AuthorizerInterceptor, AuthorizerFilter, ConnectionType, OperationGroup } from '@nestjs-query/query-graphql';
 import { Args, Query, Resolver } from '@nestjs/graphql';
 import { UseGuards, UseInterceptors } from '@nestjs/common';
 import { TodoItemDTO } from './dto/todo-item.dto';
@@ -23,7 +18,7 @@ export class TodoItemResolver {
   async completedTodoItems(
     @Args() query: TodoItemQuery,
     @AuthorizerFilter({
-      operationGroup: AuthorizationOperationGroup.READ,
+      operationGroup: OperationGroup.READ,
       many: true,
     })
     authFilter: Filter<TodoItemDTO>,
@@ -43,7 +38,9 @@ export class TodoItemResolver {
   async uncompletedTodoItems(
     @Args() query: TodoItemQuery,
     @AuthorizerFilter({
-      operationGroup: AuthorizationOperationGroup.READ,
+      operationName: 'queryUncompletedTodoItems',
+      operationGroup: OperationGroup.READ,
+      readonly: true,
       many: true,
     })
     authFilter: Filter<TodoItemDTO>,

--- a/examples/auth/src/todo-item/todo-item.resolver.ts
+++ b/examples/auth/src/todo-item/todo-item.resolver.ts
@@ -17,7 +17,7 @@ export class TodoItemResolver {
   @Query(() => TodoItemConnection)
   async completedTodoItems(
     @Args() query: TodoItemQuery,
-    @AuthorizerFilter() authFilter: Filter<TodoItemDTO>,
+    @AuthorizerFilter('queryCompletedTodoItems') authFilter: Filter<TodoItemDTO>,
   ): Promise<ConnectionType<TodoItemDTO>> {
     // add the completed filter the user provided filter
     const filter: Filter<TodoItemDTO> = mergeFilter(query.filter ?? {}, { completed: { is: true } });
@@ -33,7 +33,13 @@ export class TodoItemResolver {
   @Query(() => TodoItemConnection)
   async uncompletedTodoItems(
     @Args() query: TodoItemQuery,
-    @AuthorizerFilter() authFilter: Filter<TodoItemDTO>,
+    @AuthorizerFilter({
+      operationName: 'queryUncompletedTodoItems',
+      operationGroup: 'read',
+      readonly: true,
+      many: true,
+    })
+    authFilter: Filter<TodoItemDTO>,
   ): Promise<ConnectionType<TodoItemDTO>> {
     // add the completed filter the user provided filter
     const filter: Filter<TodoItemDTO> = mergeFilter(query.filter ?? {}, { completed: { is: false } });

--- a/package-lock.json
+++ b/package-lock.json
@@ -24453,9 +24453,9 @@
       "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw=="
     },
     "ua-parser-js": {
-      "version": "0.7.26",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.26.tgz",
-      "integrity": "sha512-VwIvGlFNmpKbjzRt51jpbbFTrKIEgGHxIwA8Y69K1Bqc6bTIV7TaGGABOkghSFQWsLmcRB4drGvpfv9z2szqoQ=="
+      "version": "0.7.27",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.27.tgz",
+      "integrity": "sha512-eXMaRYK2skomGocoX0x9sBXzx5A1ZVQgXfrW4mTc8dT0zS7olEcyfudAzRC5tIIRgLxQ69B6jut3DI+n5hslPA=="
     },
     "uglify-js": {
       "version": "3.13.0",
@@ -24880,16 +24880,16 @@
           "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
         },
         "mime-db": {
-          "version": "1.46.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
-          "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
+          "version": "1.47.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+          "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
         },
         "mime-types": {
-          "version": "2.1.29",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
-          "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+          "version": "2.1.30",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+          "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
           "requires": {
-            "mime-db": "1.46.0"
+            "mime-db": "1.47.0"
           }
         },
         "schema-utils": {

--- a/packages/query-graphql/__tests__/auth/default-crud-auth.service.spec.ts
+++ b/packages/query-graphql/__tests__/auth/default-crud-auth.service.spec.ts
@@ -83,7 +83,10 @@ describe('createDefaultAuthorizer', () => {
 
   it('should create an auth filter that depends on the passed operation name', async () => {
     const authorizer = testingModule.get<Authorizer<TestDTO>>(getAuthorizerToken(TestDTO));
-    const filter = await authorizer.authorize({ user: { id: 2 } }, { operationName: 'other' });
+    const filter = await authorizer.authorize(
+      { user: { id: 2 } },
+      { operationName: 'other', operationGroup: 'read', readonly: true, many: true },
+    );
     expect(filter).toEqual({ ownerId: { neq: 2 } });
   });
 
@@ -107,7 +110,11 @@ describe('createDefaultAuthorizer', () => {
 
   it('should create an auth filter that depends on the passed operation name for relations using the relation options', async () => {
     const authorizer = testingModule.get<Authorizer<TestDTO>>(getAuthorizerToken(TestDTO));
-    const filter = await authorizer.authorizeRelation('relations', { user: { id: 2 } }, { operationName: 'other' });
+    const filter = await authorizer.authorizeRelation(
+      'relations',
+      { user: { id: 2 } },
+      { operationName: 'other', operationGroup: 'read', readonly: true, many: true },
+    );
     expect(filter).toEqual({ relationOwnerId: { neq: 2 } });
   });
 

--- a/packages/query-graphql/__tests__/auth/default-crud-auth.service.spec.ts
+++ b/packages/query-graphql/__tests__/auth/default-crud-auth.service.spec.ts
@@ -77,7 +77,10 @@ describe('createDefaultAuthorizer', () => {
 
   it('should create an auth filter', async () => {
     const authorizer = testingModule.get<Authorizer<TestDTO>>(getAuthorizerToken(TestDTO));
-    const filter = await authorizer.authorize({ user: { id: 2 } });
+    const filter = await authorizer.authorize(
+      { user: { id: 2 } },
+      { operationName: 'queryMany', operationGroup: OperationGroup.READ, readonly: true, many: true },
+    );
     expect(filter).toEqual({ ownerId: { eq: 2 } });
   });
 
@@ -92,19 +95,30 @@ describe('createDefaultAuthorizer', () => {
 
   it('should return an empty filter if auth not found', async () => {
     const authorizer = testingModule.get<Authorizer<TestNoAuthDTO>>(getAuthorizerToken(TestNoAuthDTO));
-    const filter = await authorizer.authorize({ user: { id: 2 } });
+    const filter = await authorizer.authorize(
+      { user: { id: 2 } },
+      { operationName: 'queryMany', operationGroup: OperationGroup.READ, readonly: true, many: true },
+    );
     expect(filter).toEqual({});
   });
 
   it('should create an auth filter for relations using the default auth decorator', async () => {
     const authorizer = testingModule.get<Authorizer<TestDTO>>(getAuthorizerToken(TestDTO));
-    const filter = await authorizer.authorizeRelation('unPagedDecoratorRelations', { user: { id: 2 } });
+    const filter = await authorizer.authorizeRelation(
+      'unPagedDecoratorRelations',
+      { user: { id: 2 } },
+      { operationName: 'queryRelation', operationGroup: OperationGroup.READ, readonly: true, many: true },
+    );
     expect(filter).toEqual({ decoratorOwnerId: { eq: 2 } });
   });
 
   it('should create an auth filter for relations using the relation options', async () => {
     const authorizer = testingModule.get<Authorizer<TestDTO>>(getAuthorizerToken(TestDTO));
-    const filter = await authorizer.authorizeRelation('relations', { user: { id: 2 } });
+    const filter = await authorizer.authorizeRelation(
+      'relations',
+      { user: { id: 2 } },
+      { operationName: 'queryRelation', operationGroup: OperationGroup.READ, readonly: true, many: true },
+    );
     expect(filter).toEqual({ relationOwnerId: { eq: 2 } });
   });
 
@@ -120,13 +134,21 @@ describe('createDefaultAuthorizer', () => {
 
   it('should create an auth filter for relations using the relation authorizer', async () => {
     const authorizer = testingModule.get<Authorizer<TestDTO>>(getAuthorizerToken(TestDTO));
-    const filter = await authorizer.authorizeRelation('authorizerRelation', { user: { id: 2 } });
+    const filter = await authorizer.authorizeRelation(
+      'authorizerRelation',
+      { user: { id: 2 } },
+      { operationName: 'queryRelation', operationGroup: OperationGroup.READ, readonly: true, many: true },
+    );
     expect(filter).toEqual({ authorizerOwnerId: { eq: 2 } });
   });
 
   it('should return an empty object for an unknown relation', async () => {
     const authorizer = testingModule.get<Authorizer<TestDTO>>(getAuthorizerToken(TestDTO));
-    const filter = await authorizer.authorizeRelation('unknownRelations', { user: { id: 2 } });
+    const filter = await authorizer.authorizeRelation(
+      'unknownRelations',
+      { user: { id: 2 } },
+      { operationName: 'queryRelation', operationGroup: OperationGroup.READ, readonly: true, many: true },
+    );
     expect(filter).toEqual({});
   });
 });

--- a/packages/query-graphql/__tests__/auth/default-crud-auth.service.spec.ts
+++ b/packages/query-graphql/__tests__/auth/default-crud-auth.service.spec.ts
@@ -3,7 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { Filter } from '@nestjs-query/core';
 import { Injectable } from '@nestjs/common';
 import { Authorizer, Relation, Authorize, UnPagedRelation } from '../../src';
-import { AuthorizationContext, getAuthorizerToken } from '../../src/auth';
+import { AuthorizationContext, OperationGroup, getAuthorizerToken } from '../../src/auth';
 import { createAuthorizerProviders } from '../../src/providers';
 
 describe('createDefaultAuthorizer', () => {
@@ -85,7 +85,7 @@ describe('createDefaultAuthorizer', () => {
     const authorizer = testingModule.get<Authorizer<TestDTO>>(getAuthorizerToken(TestDTO));
     const filter = await authorizer.authorize(
       { user: { id: 2 } },
-      { operationName: 'other', operationGroup: 'read', readonly: true, many: true },
+      { operationName: 'other', operationGroup: OperationGroup.READ, readonly: true, many: true },
     );
     expect(filter).toEqual({ ownerId: { neq: 2 } });
   });
@@ -113,7 +113,7 @@ describe('createDefaultAuthorizer', () => {
     const filter = await authorizer.authorizeRelation(
       'relations',
       { user: { id: 2 } },
-      { operationName: 'other', operationGroup: 'read', readonly: true, many: true },
+      { operationName: 'other', operationGroup: OperationGroup.READ, readonly: true, many: true },
     );
     expect(filter).toEqual({ relationOwnerId: { neq: 2 } });
   });

--- a/packages/query-graphql/src/auth/authorizer.ts
+++ b/packages/query-graphql/src/auth/authorizer.ts
@@ -10,16 +10,16 @@ export enum OperationGroup {
 
 export interface AuthorizationContext {
   /** The name of the method that uses the @AuthorizeFilter decorator */
-  operationName: string;
+  readonly operationName: string;
 
   /** The group this operation belongs to */
-  operationGroup: OperationGroup;
+  readonly operationGroup: OperationGroup;
 
   /** If the operation does not modify any entities */
-  readonly: boolean;
+  readonly readonly: boolean;
 
   /** If the operation can affect multiple entities */
-  many: boolean;
+  readonly many: boolean;
 }
 
 export interface Authorizer<DTO> {

--- a/packages/query-graphql/src/auth/authorizer.ts
+++ b/packages/query-graphql/src/auth/authorizer.ts
@@ -1,7 +1,19 @@
 import { Filter } from '@nestjs-query/core';
 
+export type AuthorizationOperationGroup = 'read' | 'aggregate' | 'create' | 'update' | 'delete';
+
 export interface AuthorizationContext {
+  /** The name of the method that uses the @AuthorizeFilter decorator */
   operationName: string;
+
+  /** The group this operation belongs to */
+  operationGroup: AuthorizationOperationGroup;
+
+  /** If the operation does not modify any entities */
+  readonly: boolean;
+
+  /** If the operation can affect multiple entities */
+  many: boolean;
 }
 
 export interface Authorizer<DTO> {

--- a/packages/query-graphql/src/auth/authorizer.ts
+++ b/packages/query-graphql/src/auth/authorizer.ts
@@ -1,9 +1,17 @@
 import { Filter } from '@nestjs-query/core';
 
+export interface AuthorizationContext {
+  operationName: string;
+}
+
 export interface Authorizer<DTO> {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types,@typescript-eslint/no-explicit-any
-  authorize(context: any, operationName?: string): Promise<Filter<DTO>>;
+  authorize(context: any, authorizerContext?: AuthorizationContext): Promise<Filter<DTO>>;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  authorizeRelation(relationName: string, context: any, operationName?: string): Promise<Filter<unknown>>;
+  authorizeRelation(
+    relationName: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    context: any,
+    authorizerContext?: AuthorizationContext,
+  ): Promise<Filter<unknown>>;
 }

--- a/packages/query-graphql/src/auth/authorizer.ts
+++ b/packages/query-graphql/src/auth/authorizer.ts
@@ -24,12 +24,12 @@ export interface AuthorizationContext {
 
 export interface Authorizer<DTO> {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types,@typescript-eslint/no-explicit-any
-  authorize(context: any, authorizerContext?: AuthorizationContext): Promise<Filter<DTO>>;
+  authorize(context: any, authorizerContext: AuthorizationContext): Promise<Filter<DTO>>;
 
   authorizeRelation(
     relationName: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     context: any,
-    authorizerContext?: AuthorizationContext,
+    authorizerContext: AuthorizationContext,
   ): Promise<Filter<unknown>>;
 }

--- a/packages/query-graphql/src/auth/authorizer.ts
+++ b/packages/query-graphql/src/auth/authorizer.ts
@@ -1,13 +1,19 @@
 import { Filter } from '@nestjs-query/core';
 
-export type AuthorizationOperationGroup = 'read' | 'aggregate' | 'create' | 'update' | 'delete';
+export enum OperationGroup {
+  READ = 'read',
+  AGGREGATE = 'aggregate',
+  CREATE = 'create',
+  UPDATE = 'update',
+  DELETE = 'delete',
+}
 
 export interface AuthorizationContext {
   /** The name of the method that uses the @AuthorizeFilter decorator */
   operationName: string;
 
   /** The group this operation belongs to */
-  operationGroup: AuthorizationOperationGroup;
+  operationGroup: OperationGroup;
 
   /** If the operation does not modify any entities */
   readonly: boolean;

--- a/packages/query-graphql/src/auth/authorizer.ts
+++ b/packages/query-graphql/src/auth/authorizer.ts
@@ -2,8 +2,8 @@ import { Filter } from '@nestjs-query/core';
 
 export interface Authorizer<DTO> {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types,@typescript-eslint/no-explicit-any
-  authorize(context: any): Promise<Filter<DTO>>;
+  authorize(context: any, operationName?: string): Promise<Filter<DTO>>;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  authorizeRelation(relationName: string, context: any): Promise<Filter<unknown>>;
+  authorizeRelation(relationName: string, context: any, operationName?: string): Promise<Filter<unknown>>;
 }

--- a/packages/query-graphql/src/auth/default-crud.authorizer.ts
+++ b/packages/query-graphql/src/auth/default-crud.authorizer.ts
@@ -4,17 +4,17 @@ import { Injectable } from '@nestjs/common';
 import { getAuthorizer, getRelations } from '../decorators';
 import { getAuthorizerToken } from './tokens';
 import { ResolverRelation } from '../resolvers/relations';
-import { Authorizer } from './authorizer';
+import { Authorizer, AuthorizationContext } from './authorizer';
 
 export interface AuthorizerOptions<DTO> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  authorize: (context: any, operationName?: string) => Filter<DTO> | Promise<Filter<DTO>>;
+  authorize: (context: any, authorizationContext?: AuthorizationContext) => Filter<DTO> | Promise<Filter<DTO>>;
 }
 
 const createRelationAuthorizer = (opts: AuthorizerOptions<unknown>): Authorizer<unknown> => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async authorize(context: any, operationName?: string): Promise<Filter<unknown>> {
-    return opts.authorize(context, operationName) ?? {};
+  async authorize(context: any, authorizationContext?: AuthorizationContext): Promise<Filter<unknown>> {
+    return opts.authorize(context, authorizationContext) ?? {};
   },
   authorizeRelation(): Promise<Filter<unknown>> {
     return Promise.reject(new Error('Not implemented'));
@@ -43,13 +43,17 @@ export function createDefaultAuthorizer<DTO>(
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async authorize(context: any, operationName?: string): Promise<Filter<DTO>> {
-      return this.authOptions?.authorize(context, operationName) ?? {};
+    async authorize(context: any, authorizationContext?: AuthorizationContext): Promise<Filter<DTO>> {
+      return this.authOptions?.authorize(context, authorizationContext) ?? {};
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async authorizeRelation(relationName: string, context: any, operationName?: string): Promise<Filter<unknown>> {
-      return this.relationsAuthorizers.get(relationName)?.authorize(context, operationName) ?? {};
+    async authorizeRelation(
+      relationName: string,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      context: any,
+      authorizationContext?: AuthorizationContext,
+    ): Promise<Filter<unknown>> {
+      return this.relationsAuthorizers.get(relationName)?.authorize(context, authorizationContext) ?? {};
     }
 
     private get relations(): Map<string, ResolverRelation<unknown>> {

--- a/packages/query-graphql/src/auth/default-crud.authorizer.ts
+++ b/packages/query-graphql/src/auth/default-crud.authorizer.ts
@@ -8,13 +8,13 @@ import { Authorizer } from './authorizer';
 
 export interface AuthorizerOptions<DTO> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  authorize: (context: any) => Filter<DTO> | Promise<Filter<DTO>>;
+  authorize: (context: any, operationName?: string) => Filter<DTO> | Promise<Filter<DTO>>;
 }
 
 const createRelationAuthorizer = (opts: AuthorizerOptions<unknown>): Authorizer<unknown> => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async authorize(context: any): Promise<Filter<unknown>> {
-    return opts.authorize(context) ?? {};
+  async authorize(context: any, operationName?: string): Promise<Filter<unknown>> {
+    return opts.authorize(context, operationName) ?? {};
   },
   authorizeRelation(): Promise<Filter<unknown>> {
     return Promise.reject(new Error('Not implemented'));
@@ -43,13 +43,13 @@ export function createDefaultAuthorizer<DTO>(
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async authorize(context: any): Promise<Filter<DTO>> {
-      return this.authOptions?.authorize(context) ?? {};
+    async authorize(context: any, operationName?: string): Promise<Filter<DTO>> {
+      return this.authOptions?.authorize(context, operationName) ?? {};
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async authorizeRelation(relationName: string, context: any): Promise<Filter<unknown>> {
-      return this.relationsAuthorizers.get(relationName)?.authorize(context) ?? {};
+    async authorizeRelation(relationName: string, context: any, operationName?: string): Promise<Filter<unknown>> {
+      return this.relationsAuthorizers.get(relationName)?.authorize(context, operationName) ?? {};
     }
 
     private get relations(): Map<string, ResolverRelation<unknown>> {

--- a/packages/query-graphql/src/auth/default-crud.authorizer.ts
+++ b/packages/query-graphql/src/auth/default-crud.authorizer.ts
@@ -8,12 +8,12 @@ import { Authorizer, AuthorizationContext } from './authorizer';
 
 export interface AuthorizerOptions<DTO> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  authorize: (context: any, authorizationContext?: AuthorizationContext) => Filter<DTO> | Promise<Filter<DTO>>;
+  authorize: (context: any, authorizationContext: AuthorizationContext) => Filter<DTO> | Promise<Filter<DTO>>;
 }
 
 const createRelationAuthorizer = (opts: AuthorizerOptions<unknown>): Authorizer<unknown> => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async authorize(context: any, authorizationContext?: AuthorizationContext): Promise<Filter<unknown>> {
+  async authorize(context: any, authorizationContext: AuthorizationContext): Promise<Filter<unknown>> {
     return opts.authorize(context, authorizationContext) ?? {};
   },
   authorizeRelation(): Promise<Filter<unknown>> {
@@ -43,7 +43,7 @@ export function createDefaultAuthorizer<DTO>(
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async authorize(context: any, authorizationContext?: AuthorizationContext): Promise<Filter<DTO>> {
+    async authorize(context: any, authorizationContext: AuthorizationContext): Promise<Filter<DTO>> {
       return this.authOptions?.authorize(context, authorizationContext) ?? {};
     }
 
@@ -51,7 +51,7 @@ export function createDefaultAuthorizer<DTO>(
       relationName: string,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       context: any,
-      authorizationContext?: AuthorizationContext,
+      authorizationContext: AuthorizationContext,
     ): Promise<Filter<unknown>> {
       return this.relationsAuthorizers.get(relationName)?.authorize(context, authorizationContext) ?? {};
     }

--- a/packages/query-graphql/src/decorators/authorize-filter.decorator.ts
+++ b/packages/query-graphql/src/decorators/authorize-filter.decorator.ts
@@ -14,7 +14,7 @@ function getContext<C>(executionContext: ExecutionContext): C {
 
 function getAuthorizerFilter<C extends AuthorizerContext<unknown>>(
   context: C,
-  authorizationContext?: AuthorizationContext,
+  authorizationContext: AuthorizationContext,
 ) {
   if (!context.authorizer) {
     return undefined;
@@ -25,7 +25,7 @@ function getAuthorizerFilter<C extends AuthorizerContext<unknown>>(
 function getRelationAuthFilter<C extends AuthorizerContext<unknown>>(
   context: C,
   relationName: string,
-  authorizationContext?: AuthorizationContext,
+  authorizationContext: AuthorizationContext,
 ) {
   if (!context.authorizer) {
     return undefined;
@@ -36,8 +36,15 @@ function getRelationAuthFilter<C extends AuthorizerContext<unknown>>(
 function getAuthorizationContext(
   methodName: string | symbol,
   partialAuthContext?: PartialAuthorizationContext,
-): AuthorizationContext | undefined {
-  if (!partialAuthContext) return undefined;
+): AuthorizationContext {
+  if (!partialAuthContext)
+    return new Proxy<AuthorizationContext>({} as AuthorizationContext, {
+      get: () => {
+        throw new Error(
+          `No AuthorizationContext available for method ${methodName.toString()}! Make sure that you provide an AuthorizationContext to your custom methods as argument of the @AuthorizerFilter decorator.`,
+        );
+      },
+    });
 
   return {
     operationName: methodName.toString(),

--- a/packages/query-graphql/src/decorators/authorize-filter.decorator.ts
+++ b/packages/query-graphql/src/decorators/authorize-filter.decorator.ts
@@ -1,8 +1,11 @@
 import { ModifyRelationOptions } from '@nestjs-query/core';
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
-import { AuthorizationContext, AuthorizationOperationGroup } from '../auth';
+import { AuthorizationContext, OperationGroup } from '../auth';
 import { AuthorizerContext } from '../interceptors';
+
+type PartialAuthorizationContext = Partial<AuthorizationContext> &
+  Pick<AuthorizationContext, 'operationGroup' | 'many'>;
 
 function getContext<C>(executionContext: ExecutionContext): C {
   const gqlExecutionContext = GqlExecutionContext.create(executionContext);
@@ -11,7 +14,7 @@ function getContext<C>(executionContext: ExecutionContext): C {
 
 function getAuthorizerFilter<C extends AuthorizerContext<unknown>>(
   context: C,
-  authorizationContext: AuthorizationContext,
+  authorizationContext?: AuthorizationContext,
 ) {
   if (!context.authorizer) {
     return undefined;
@@ -22,7 +25,7 @@ function getAuthorizerFilter<C extends AuthorizerContext<unknown>>(
 function getRelationAuthFilter<C extends AuthorizerContext<unknown>>(
   context: C,
   relationName: string,
-  authorizationContext: AuthorizationContext,
+  authorizationContext?: AuthorizationContext,
 ) {
   if (!context.authorizer) {
     return undefined;
@@ -30,80 +33,51 @@ function getRelationAuthFilter<C extends AuthorizerContext<unknown>>(
   return context.authorizer.authorizeRelation(relationName, context, authorizationContext);
 }
 
-function getAuthorizationContext(operationNameOrContext: string | AuthorizationContext): AuthorizationContext {
-  if (typeof operationNameOrContext !== 'string') {
-    return operationNameOrContext;
-  }
-
-  const lcMethodName = operationNameOrContext.toLowerCase();
-
-  const isCreate = lcMethodName.startsWith('create');
-  const isUpdate = lcMethodName.startsWith('update') || lcMethodName.startsWith('set');
-  const isDelete = lcMethodName.startsWith('delete') || lcMethodName.startsWith('remove');
-  const isAggregate = lcMethodName.startsWith('aggregate');
-  const isQuery = lcMethodName.startsWith('query');
-  const isFind = lcMethodName.startsWith('find');
-  const isMany = lcMethodName.endsWith('many');
-
-  let operationGroup: AuthorizationOperationGroup = 'read';
-
-  if (isCreate) {
-    operationGroup = 'create';
-  } else if (isDelete) {
-    operationGroup = 'delete';
-  } else if (isUpdate) {
-    operationGroup = 'update';
-  } else if (isAggregate) {
-    operationGroup = 'aggregate';
-  }
+function getAuthorizationContext(
+  methodName: string | symbol,
+  partialAuthContext?: PartialAuthorizationContext,
+): AuthorizationContext | undefined {
+  if (!partialAuthContext) return undefined;
 
   return {
-    operationName: operationNameOrContext,
-    operationGroup,
-    readonly: isQuery || isFind || isAggregate,
-    many: isMany || isQuery || isAggregate,
+    operationName: methodName.toString(),
+    readonly:
+      partialAuthContext.operationGroup === OperationGroup.READ ||
+      partialAuthContext.operationGroup === OperationGroup.AGGREGATE,
+    ...partialAuthContext,
   };
 }
 
-export function AuthorizerFilter(): ParameterDecorator;
-export function AuthorizerFilter(context: AuthorizationContext): ParameterDecorator;
-export function AuthorizerFilter(operationName: string): ParameterDecorator;
-export function AuthorizerFilter<DTO>(operationNameOrContext?: string | AuthorizationContext): ParameterDecorator {
+export function AuthorizerFilter<DTO>(partialAuthContext?: PartialAuthorizationContext): ParameterDecorator {
   // eslint-disable-next-line @typescript-eslint/ban-types
   return (target: Object, propertyKey: string | symbol, parameterIndex: number) => {
-    const authorizationContext = getAuthorizationContext(operationNameOrContext ?? propertyKey.toString());
+    const authorizationContext = getAuthorizationContext(propertyKey, partialAuthContext);
     return createParamDecorator((data: unknown, executionContext: ExecutionContext) =>
       getAuthorizerFilter(getContext<AuthorizerContext<DTO>>(executionContext), authorizationContext),
     )()(target, propertyKey, parameterIndex);
   };
 }
 
-export function RelationAuthorizerFilter(relationName: string): ParameterDecorator;
-export function RelationAuthorizerFilter(relationName: string, operationName: string): ParameterDecorator;
-export function RelationAuthorizerFilter(relationName: string, context: AuthorizationContext): ParameterDecorator;
 export function RelationAuthorizerFilter<DTO>(
   relationName: string,
-  operationNameOrContext?: string | AuthorizationContext,
+  partialAuthContext?: PartialAuthorizationContext,
 ): ParameterDecorator {
   // eslint-disable-next-line @typescript-eslint/ban-types
   return (target: Object, propertyKey: string | symbol, parameterIndex: number) => {
-    const authorizationContext = getAuthorizationContext(operationNameOrContext ?? propertyKey.toString());
+    const authorizationContext = getAuthorizationContext(propertyKey, partialAuthContext);
     return createParamDecorator((data: unknown, executionContext: ExecutionContext) =>
       getRelationAuthFilter(getContext<AuthorizerContext<DTO>>(executionContext), relationName, authorizationContext),
     )()(target, propertyKey, parameterIndex);
   };
 }
 
-export function ModifyRelationAuthorizerFilter(relationName: string): ParameterDecorator;
-export function ModifyRelationAuthorizerFilter(relationName: string, operationName: string): ParameterDecorator;
-export function ModifyRelationAuthorizerFilter(relationName: string, context: AuthorizationContext): ParameterDecorator;
 export function ModifyRelationAuthorizerFilter<DTO>(
   relationName: string,
-  operationNameOrContext?: string | AuthorizationContext,
+  partialAuthContext?: PartialAuthorizationContext,
 ): ParameterDecorator {
   // eslint-disable-next-line @typescript-eslint/ban-types
   return (target: Object, propertyKey: string | symbol, parameterIndex: number) => {
-    const authorizationContext = getAuthorizationContext(operationNameOrContext ?? propertyKey.toString());
+    const authorizationContext = getAuthorizationContext(propertyKey, partialAuthContext);
     return createParamDecorator(
       async (data: unknown, executionContext: ExecutionContext): Promise<ModifyRelationOptions<unknown, unknown>> => {
         const context = getContext<AuthorizerContext<DTO>>(executionContext);

--- a/packages/query-graphql/src/decorators/authorize-filter.decorator.ts
+++ b/packages/query-graphql/src/decorators/authorize-filter.decorator.ts
@@ -1,6 +1,7 @@
 import { ModifyRelationOptions } from '@nestjs-query/core';
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
+import { AuthorizationContext } from '../auth';
 import { AuthorizerContext } from '../interceptors';
 
 function getContext<C>(executionContext: ExecutionContext): C {
@@ -8,30 +9,35 @@ function getContext<C>(executionContext: ExecutionContext): C {
   return gqlExecutionContext.getContext<C>();
 }
 
-function getAuthorizerFilter<C extends AuthorizerContext<unknown>>(context: C, operationName: string) {
+function getAuthorizerFilter<C extends AuthorizerContext<unknown>>(
+  context: C,
+  authorizationContext: AuthorizationContext,
+) {
   if (!context.authorizer) {
     return undefined;
   }
-  return context.authorizer.authorize(context, operationName);
+  return context.authorizer.authorize(context, authorizationContext);
 }
 
 function getRelationAuthFilter<C extends AuthorizerContext<unknown>>(
   context: C,
   relationName: string,
-  operationName: string,
+  authorizationContext: AuthorizationContext,
 ) {
   if (!context.authorizer) {
     return undefined;
   }
-  return context.authorizer.authorizeRelation(relationName, context, operationName);
+  return context.authorizer.authorizeRelation(relationName, context, authorizationContext);
 }
 
 export function AuthorizerFilter<DTO>(operationName?: string): ParameterDecorator {
   // eslint-disable-next-line @typescript-eslint/ban-types
   return (target: Object, propertyKey: string | symbol, parameterIndex: number) => {
-    const name = operationName ?? propertyKey.toString();
+    const authorizationContext: AuthorizationContext = {
+      operationName: operationName ?? propertyKey.toString(),
+    };
     return createParamDecorator((data: unknown, executionContext: ExecutionContext) =>
-      getAuthorizerFilter(getContext<AuthorizerContext<DTO>>(executionContext), name),
+      getAuthorizerFilter(getContext<AuthorizerContext<DTO>>(executionContext), authorizationContext),
     )()(target, propertyKey, parameterIndex);
   };
 }
@@ -39,9 +45,11 @@ export function AuthorizerFilter<DTO>(operationName?: string): ParameterDecorato
 export function RelationAuthorizerFilter<DTO>(relationName: string, operationName?: string): ParameterDecorator {
   // eslint-disable-next-line @typescript-eslint/ban-types
   return (target: Object, propertyKey: string | symbol, parameterIndex: number) => {
-    const name = operationName ?? propertyKey.toString();
+    const authorizationContext: AuthorizationContext = {
+      operationName: operationName ?? propertyKey.toString(),
+    };
     return createParamDecorator((data: unknown, executionContext: ExecutionContext) =>
-      getRelationAuthFilter(getContext<AuthorizerContext<DTO>>(executionContext), relationName, name),
+      getRelationAuthFilter(getContext<AuthorizerContext<DTO>>(executionContext), relationName, authorizationContext),
     )()(target, propertyKey, parameterIndex);
   };
 }
@@ -49,13 +57,15 @@ export function RelationAuthorizerFilter<DTO>(relationName: string, operationNam
 export function ModifyRelationAuthorizerFilter<DTO>(relationName: string, operationName?: string): ParameterDecorator {
   // eslint-disable-next-line @typescript-eslint/ban-types
   return (target: Object, propertyKey: string | symbol, parameterIndex: number) => {
-    const name = operationName ?? propertyKey.toString();
+    const authorizationContext: AuthorizationContext = {
+      operationName: operationName ?? propertyKey.toString(),
+    };
     return createParamDecorator(
       async (data: unknown, executionContext: ExecutionContext): Promise<ModifyRelationOptions<unknown, unknown>> => {
         const context = getContext<AuthorizerContext<DTO>>(executionContext);
         return {
-          filter: await getAuthorizerFilter(context, name),
-          relationFilter: await getRelationAuthFilter(context, relationName, name),
+          filter: await getAuthorizerFilter(context, authorizationContext),
+          relationFilter: await getRelationAuthFilter(context, relationName, authorizationContext),
         };
       },
     )()(target, propertyKey, parameterIndex);

--- a/packages/query-graphql/src/decorators/authorize-filter.decorator.ts
+++ b/packages/query-graphql/src/decorators/authorize-filter.decorator.ts
@@ -1,7 +1,7 @@
 import { ModifyRelationOptions } from '@nestjs-query/core';
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
-import { AuthorizationContext } from '../auth';
+import { AuthorizationContext, AuthorizationOperationGroup } from '../auth';
 import { AuthorizerContext } from '../interceptors';
 
 function getContext<C>(executionContext: ExecutionContext): C {
@@ -30,36 +30,80 @@ function getRelationAuthFilter<C extends AuthorizerContext<unknown>>(
   return context.authorizer.authorizeRelation(relationName, context, authorizationContext);
 }
 
-export function AuthorizerFilter<DTO>(operationName?: string): ParameterDecorator {
+function getAuthorizationContext(operationNameOrContext: string | AuthorizationContext): AuthorizationContext {
+  if (typeof operationNameOrContext !== 'string') {
+    return operationNameOrContext;
+  }
+
+  const lcMethodName = operationNameOrContext.toLowerCase();
+
+  const isCreate = lcMethodName.startsWith('create');
+  const isUpdate = lcMethodName.startsWith('update') || lcMethodName.startsWith('set');
+  const isDelete = lcMethodName.startsWith('delete') || lcMethodName.startsWith('remove');
+  const isAggregate = lcMethodName.startsWith('aggregate');
+  const isQuery = lcMethodName.startsWith('query');
+  const isFind = lcMethodName.startsWith('find');
+  const isMany = lcMethodName.endsWith('many');
+
+  let operationGroup: AuthorizationOperationGroup = 'read';
+
+  if (isCreate) {
+    operationGroup = 'create';
+  } else if (isDelete) {
+    operationGroup = 'delete';
+  } else if (isUpdate) {
+    operationGroup = 'update';
+  } else if (isAggregate) {
+    operationGroup = 'aggregate';
+  }
+
+  return {
+    operationName: operationNameOrContext,
+    operationGroup,
+    readonly: isQuery || isFind || isAggregate,
+    many: isMany || isQuery || isAggregate,
+  };
+}
+
+export function AuthorizerFilter(): ParameterDecorator;
+export function AuthorizerFilter(context: AuthorizationContext): ParameterDecorator;
+export function AuthorizerFilter(operationName: string): ParameterDecorator;
+export function AuthorizerFilter<DTO>(operationNameOrContext?: string | AuthorizationContext): ParameterDecorator {
   // eslint-disable-next-line @typescript-eslint/ban-types
   return (target: Object, propertyKey: string | symbol, parameterIndex: number) => {
-    const authorizationContext: AuthorizationContext = {
-      operationName: operationName ?? propertyKey.toString(),
-    };
+    const authorizationContext = getAuthorizationContext(operationNameOrContext ?? propertyKey.toString());
     return createParamDecorator((data: unknown, executionContext: ExecutionContext) =>
       getAuthorizerFilter(getContext<AuthorizerContext<DTO>>(executionContext), authorizationContext),
     )()(target, propertyKey, parameterIndex);
   };
 }
 
-export function RelationAuthorizerFilter<DTO>(relationName: string, operationName?: string): ParameterDecorator {
+export function RelationAuthorizerFilter(relationName: string): ParameterDecorator;
+export function RelationAuthorizerFilter(relationName: string, operationName: string): ParameterDecorator;
+export function RelationAuthorizerFilter(relationName: string, context: AuthorizationContext): ParameterDecorator;
+export function RelationAuthorizerFilter<DTO>(
+  relationName: string,
+  operationNameOrContext?: string | AuthorizationContext,
+): ParameterDecorator {
   // eslint-disable-next-line @typescript-eslint/ban-types
   return (target: Object, propertyKey: string | symbol, parameterIndex: number) => {
-    const authorizationContext: AuthorizationContext = {
-      operationName: operationName ?? propertyKey.toString(),
-    };
+    const authorizationContext = getAuthorizationContext(operationNameOrContext ?? propertyKey.toString());
     return createParamDecorator((data: unknown, executionContext: ExecutionContext) =>
       getRelationAuthFilter(getContext<AuthorizerContext<DTO>>(executionContext), relationName, authorizationContext),
     )()(target, propertyKey, parameterIndex);
   };
 }
 
-export function ModifyRelationAuthorizerFilter<DTO>(relationName: string, operationName?: string): ParameterDecorator {
+export function ModifyRelationAuthorizerFilter(relationName: string): ParameterDecorator;
+export function ModifyRelationAuthorizerFilter(relationName: string, operationName: string): ParameterDecorator;
+export function ModifyRelationAuthorizerFilter(relationName: string, context: AuthorizationContext): ParameterDecorator;
+export function ModifyRelationAuthorizerFilter<DTO>(
+  relationName: string,
+  operationNameOrContext?: string | AuthorizationContext,
+): ParameterDecorator {
   // eslint-disable-next-line @typescript-eslint/ban-types
   return (target: Object, propertyKey: string | symbol, parameterIndex: number) => {
-    const authorizationContext: AuthorizationContext = {
-      operationName: operationName ?? propertyKey.toString(),
-    };
+    const authorizationContext = getAuthorizationContext(operationNameOrContext ?? propertyKey.toString());
     return createParamDecorator(
       async (data: unknown, executionContext: ExecutionContext): Promise<ModifyRelationOptions<unknown, unknown>> => {
         const context = getContext<AuthorizerContext<DTO>>(executionContext);

--- a/packages/query-graphql/src/index.ts
+++ b/packages/query-graphql/src/index.ts
@@ -40,12 +40,7 @@ export { DTONamesOpts } from './common';
 export { NestjsQueryGraphQLModule } from './module';
 export { AutoResolverOpts } from './providers';
 export { pubSubToken, GraphQLPubSub } from './subscription';
-export {
-  Authorizer,
-  AuthorizerOptions,
-  AuthorizationContext,
-  OperationGroup as AuthorizationOperationGroup,
-} from './auth';
+export { Authorizer, AuthorizerOptions, AuthorizationContext, OperationGroup } from './auth';
 export {
   Hook,
   HookTypes,

--- a/packages/query-graphql/src/index.ts
+++ b/packages/query-graphql/src/index.ts
@@ -40,7 +40,12 @@ export { DTONamesOpts } from './common';
 export { NestjsQueryGraphQLModule } from './module';
 export { AutoResolverOpts } from './providers';
 export { pubSubToken, GraphQLPubSub } from './subscription';
-export { Authorizer, AuthorizerOptions, AuthorizationContext } from './auth';
+export {
+  Authorizer,
+  AuthorizerOptions,
+  AuthorizationContext,
+  OperationGroup as AuthorizationOperationGroup,
+} from './auth';
 export {
   Hook,
   HookTypes,

--- a/packages/query-graphql/src/index.ts
+++ b/packages/query-graphql/src/index.ts
@@ -40,7 +40,7 @@ export { DTONamesOpts } from './common';
 export { NestjsQueryGraphQLModule } from './module';
 export { AutoResolverOpts } from './providers';
 export { pubSubToken, GraphQLPubSub } from './subscription';
-export { Authorizer, AuthorizerOptions } from './auth';
+export { Authorizer, AuthorizerOptions, AuthorizationContext } from './auth';
 export {
   Hook,
   HookTypes,

--- a/packages/query-graphql/src/resolvers/aggregate.resolver.ts
+++ b/packages/query-graphql/src/resolvers/aggregate.resolver.ts
@@ -7,6 +7,7 @@ import { AggregateQueryParam, AuthorizerFilter, ResolverMethodOpts, ResolverQuer
 import { AggregateArgsType, AggregateResponseType } from '../types';
 import { transformAndValidate } from './helpers';
 import { BaseServiceResolver, ResolverClass, ServiceResolver } from './resolver.interface';
+import { OperationGroup } from '../auth';
 
 export type AggregateResolverOpts = {
   enabled?: boolean;
@@ -51,7 +52,11 @@ export const Aggregateable = <DTO, QS extends QueryService<DTO, unknown, unknown
     async aggregate(
       @Args() args: AA,
       @AggregateQueryParam() query: AggregateQuery<DTO>,
-      @AuthorizerFilter() authFilter?: Filter<DTO>,
+      @AuthorizerFilter({
+        operationGroup: OperationGroup.AGGREGATE,
+        many: true,
+      })
+      authFilter?: Filter<DTO>,
     ): Promise<AggregateResponse<DTO>[]> {
       const qa = await transformAndValidate(AA, args);
       return this.service.aggregate(mergeFilter(qa.filter || {}, authFilter ?? {}), query);

--- a/packages/query-graphql/src/resolvers/create.resolver.ts
+++ b/packages/query-graphql/src/resolvers/create.resolver.ts
@@ -20,6 +20,7 @@ import {
 } from '../types';
 import { createSubscriptionFilter } from './helpers';
 import { BaseServiceResolver, ResolverClass, ServiceResolver, SubscriptionResolverOpts } from './resolver.interface';
+import { OperationGroup } from '../auth';
 
 export type CreatedEvent<DTO> = { [eventName: string]: DTO };
 
@@ -135,8 +136,14 @@ export const Creatable = <DTO, C, QS extends QueryService<DTO, C, unknown>>(
       },
       opts.one ?? {},
     )
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    async createOne(@MutationHookArgs() input: CO, @AuthorizerFilter() authorizeFilter?: Filter<DTO>): Promise<DTO> {
+    async createOne(
+      @MutationHookArgs() input: CO,
+      @AuthorizerFilter({
+        operationGroup: OperationGroup.CREATE,
+        many: false,
+      }) // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      authorizeFilter?: Filter<DTO>,
+    ): Promise<DTO> {
       // Ignore `authorizeFilter` for now but give users the ability to throw an UnauthorizedException
       const created = await this.service.createOne(input.input.input);
       if (enableOneSubscriptions) {
@@ -157,8 +164,15 @@ export const Creatable = <DTO, C, QS extends QueryService<DTO, C, unknown>>(
       },
       opts.many ?? {},
     )
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    async createMany(@MutationHookArgs() input: CM, @AuthorizerFilter() authorizeFilter?: Filter<DTO>): Promise<DTO[]> {
+    async createMany(
+      @MutationHookArgs() input: CM,
+
+      @AuthorizerFilter({
+        operationGroup: OperationGroup.CREATE,
+        many: true,
+      }) // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      authorizeFilter?: Filter<DTO>,
+    ): Promise<DTO[]> {
       // Ignore `authorizeFilter` for now but give users the ability to throw an UnauthorizedException
       const created = await this.service.createMany(input.input.input);
       if (enableManySubscriptions) {

--- a/packages/query-graphql/src/resolvers/delete.resolver.ts
+++ b/packages/query-graphql/src/resolvers/delete.resolver.ts
@@ -129,7 +129,7 @@ export const Deletable = <DTO, QS extends QueryService<DTO, unknown, unknown>>(
       @MutationHookArgs() input: DM,
       @AuthorizerFilter({
         operationGroup: OperationGroup.DELETE,
-        many: false,
+        many: true,
       })
       authorizeFilter?: Filter<DTO>,
     ): Promise<DeleteManyResponse> {

--- a/packages/query-graphql/src/resolvers/delete.resolver.ts
+++ b/packages/query-graphql/src/resolvers/delete.resolver.ts
@@ -17,6 +17,7 @@ import {
 import { MutationHookArgs, ResolverMutation, ResolverSubscription, AuthorizerFilter } from '../decorators';
 import { createSubscriptionFilter } from './helpers';
 import { AuthorizerInterceptor, HookInterceptor } from '../interceptors';
+import { OperationGroup } from '../auth';
 
 export type DeletedEvent<DTO> = { [eventName: string]: DTO };
 export interface DeleteResolverOpts<DTO> extends SubscriptionResolverOpts {
@@ -104,7 +105,11 @@ export const Deletable = <DTO, QS extends QueryService<DTO, unknown, unknown>>(
     )
     async deleteOne(
       @MutationHookArgs() input: DO,
-      @AuthorizerFilter() authorizeFilter?: Filter<DTO>,
+      @AuthorizerFilter({
+        operationGroup: OperationGroup.DELETE,
+        many: false,
+      })
+      authorizeFilter?: Filter<DTO>,
     ): Promise<Partial<DTO>> {
       const deletedResponse = await this.service.deleteOne(input.input.id, { filter: authorizeFilter ?? {} });
       if (enableOneSubscriptions) {
@@ -122,7 +127,11 @@ export const Deletable = <DTO, QS extends QueryService<DTO, unknown, unknown>>(
     )
     async deleteMany(
       @MutationHookArgs() input: DM,
-      @AuthorizerFilter() authorizeFilter?: Filter<DTO>,
+      @AuthorizerFilter({
+        operationGroup: OperationGroup.DELETE,
+        many: false,
+      })
+      authorizeFilter?: Filter<DTO>,
     ): Promise<DeleteManyResponse> {
       const deleteManyResponse = await this.service.deleteMany(mergeFilter(input.input.filter, authorizeFilter ?? {}));
       if (enableManySubscriptions) {

--- a/packages/query-graphql/src/resolvers/read.resolver.ts
+++ b/packages/query-graphql/src/resolvers/read.resolver.ts
@@ -21,6 +21,7 @@ import {
 } from './resolver.interface';
 import { AuthorizerInterceptor, HookInterceptor } from '../interceptors';
 import { HookTypes } from '../hooks';
+import { OperationGroup } from '../auth';
 
 export type ReadResolverFromOpts<
   DTO,
@@ -73,7 +74,14 @@ export const Readable = <DTO, ReadOpts extends ReadResolverOpts<DTO>, QS extends
       { interceptors: [HookInterceptor(HookTypes.BEFORE_FIND_ONE, DTOClass), AuthorizerInterceptor(DTOClass)] },
       opts.one ?? {},
     )
-    async findById(@HookArgs() input: FO, @AuthorizerFilter() authorizeFilter?: Filter<DTO>): Promise<DTO | undefined> {
+    async findById(
+      @HookArgs() input: FO,
+      @AuthorizerFilter({
+        operationGroup: OperationGroup.READ,
+        many: false,
+      })
+      authorizeFilter?: Filter<DTO>,
+    ): Promise<DTO | undefined> {
       return this.service.findById(input.id, { filter: authorizeFilter });
     }
 
@@ -86,7 +94,11 @@ export const Readable = <DTO, ReadOpts extends ReadResolverOpts<DTO>, QS extends
     )
     async queryMany(
       @HookArgs() query: QA,
-      @AuthorizerFilter('query') authorizeFilter?: Filter<DTO>,
+      @AuthorizerFilter({
+        operationGroup: OperationGroup.READ,
+        many: true,
+      })
+      authorizeFilter?: Filter<DTO>,
     ): Promise<InstanceType<typeof ConnectionType>> {
       return ConnectionType.createFromPromise(
         (q) => this.service.query(q),

--- a/packages/query-graphql/src/resolvers/read.resolver.ts
+++ b/packages/query-graphql/src/resolvers/read.resolver.ts
@@ -86,7 +86,7 @@ export const Readable = <DTO, ReadOpts extends ReadResolverOpts<DTO>, QS extends
     )
     async queryMany(
       @HookArgs() query: QA,
-      @AuthorizerFilter() authorizeFilter?: Filter<DTO>,
+      @AuthorizerFilter('query') authorizeFilter?: Filter<DTO>,
     ): Promise<InstanceType<typeof ConnectionType>> {
       return ConnectionType.createFromPromise(
         (q) => this.service.query(q),

--- a/packages/query-graphql/src/resolvers/relations/aggregate-relations.resolver.ts
+++ b/packages/query-graphql/src/resolvers/relations/aggregate-relations.resolver.ts
@@ -1,6 +1,7 @@
 import { AggregateQuery, AggregateResponse, Class, Filter, mergeFilter, QueryService } from '@nestjs-query/core';
 import { ExecutionContext } from '@nestjs/common';
 import { Args, ArgsType, Context, Parent, Resolver } from '@nestjs/graphql';
+import { OperationGroup } from '../../auth';
 import { getDTONames } from '../../common';
 import { AggregateQueryParam, RelationAuthorizerFilter, ResolverField } from '../../decorators';
 import { AuthorizerInterceptor } from '../../interceptors';
@@ -53,7 +54,11 @@ const AggregateRelationMixin = <DTO, Relation>(DTOClass: Class<DTO>, relation: A
       @Args() q: RelationQA,
       @AggregateQueryParam() aggregateQuery: AggregateQuery<Relation>,
       @Context() context: ExecutionContext,
-      @RelationAuthorizerFilter(baseNameLower) relationFilter?: Filter<Relation>,
+      @RelationAuthorizerFilter(baseNameLower, {
+        operationGroup: OperationGroup.AGGREGATE,
+        many: true,
+      })
+      relationFilter?: Filter<Relation>,
     ): Promise<AggregateResponse<Relation>> {
       const qa = await transformAndValidate(RelationQA, q);
       const loader = DataLoaderFactory.getOrCreateLoader(

--- a/packages/query-graphql/src/resolvers/relations/read-relations.resolver.ts
+++ b/packages/query-graphql/src/resolvers/relations/read-relations.resolver.ts
@@ -1,6 +1,7 @@
 import { Class, Filter, mergeQuery, QueryService } from '@nestjs-query/core';
 import { ExecutionContext } from '@nestjs/common';
 import { Args, ArgsType, Context, Parent, Resolver } from '@nestjs/graphql';
+import { OperationGroup } from '../../auth';
 import { getDTONames } from '../../common';
 import { RelationAuthorizerFilter, ResolverField } from '../../decorators';
 import { AuthorizerInterceptor } from '../../interceptors';
@@ -42,7 +43,11 @@ const ReadOneRelationMixin = <DTO, Relation>(DTOClass: Class<DTO>, relation: Res
     async [`find${baseName}`](
       @Parent() dto: DTO,
       @Context() context: ExecutionContext,
-      @RelationAuthorizerFilter(baseNameLower) authFilter?: Filter<Relation>,
+      @RelationAuthorizerFilter(baseNameLower, {
+        operationGroup: OperationGroup.READ,
+        many: false,
+      })
+      authFilter?: Filter<Relation>,
     ): Promise<Relation | undefined> {
       return DataLoaderFactory.getOrCreateLoader(context, loaderName, findLoader.createLoader(this.service)).load({
         dto,
@@ -89,7 +94,11 @@ const ReadManyRelationMixin = <DTO, Relation>(DTOClass: Class<DTO>, relation: Re
       @Parent() dto: DTO,
       @Args() q: RelationQA,
       @Context() context: ExecutionContext,
-      @RelationAuthorizerFilter(pluralBaseNameLower) relationFilter?: Filter<Relation>,
+      @RelationAuthorizerFilter(pluralBaseNameLower, {
+        operationGroup: OperationGroup.READ,
+        many: true,
+      })
+      relationFilter?: Filter<Relation>,
     ): Promise<InstanceType<typeof CT>> {
       const qa = await transformAndValidate(RelationQA, q);
       const relationLoader = DataLoaderFactory.getOrCreateLoader(

--- a/packages/query-graphql/src/resolvers/relations/remove-relations.resolver.ts
+++ b/packages/query-graphql/src/resolvers/relations/remove-relations.resolver.ts
@@ -1,5 +1,6 @@
 import { Class, ModifyRelationOptions, QueryService } from '@nestjs-query/core';
 import { Resolver, ArgsType, Args } from '@nestjs/graphql';
+import { OperationGroup } from '../../auth';
 import { getDTONames } from '../../common';
 import { ModifyRelationAuthorizerFilter, ResolverMutation } from '../../decorators';
 import { AuthorizerInterceptor } from '../../interceptors';
@@ -30,7 +31,11 @@ const RemoveOneRelationMixin = <DTO, Relation>(DTOClass: Class<DTO>, relation: R
     @ResolverMutation(() => DTOClass, {}, commonResolverOpts, { interceptors: [AuthorizerInterceptor(DTOClass)] })
     async [`remove${baseName}From${dtoNames.baseName}`](
       @Args() setArgs: SetArgs,
-      @ModifyRelationAuthorizerFilter(baseNameLower) modifyRelationsFilter?: ModifyRelationOptions<DTO, Relation>,
+      @ModifyRelationAuthorizerFilter(baseNameLower, {
+        operationGroup: OperationGroup.UPDATE,
+        many: false,
+      })
+      modifyRelationsFilter?: ModifyRelationOptions<DTO, Relation>,
     ): Promise<DTO> {
       const { input } = await transformAndValidate(SetArgs, setArgs);
       return this.service.removeRelation(relationName, input.id, input.relationId, modifyRelationsFilter);
@@ -60,7 +65,11 @@ const RemoveManyRelationsMixin = <DTO, Relation>(DTOClass: Class<DTO>, relation:
     @ResolverMutation(() => DTOClass, {}, commonResolverOpts, { interceptors: [AuthorizerInterceptor(DTOClass)] })
     async [`remove${pluralBaseName}From${dtoNames.baseName}`](
       @Args() addArgs: AddArgs,
-      @ModifyRelationAuthorizerFilter(pluralBaseNameLower) modifyRelationsFilter?: ModifyRelationOptions<DTO, Relation>,
+      @ModifyRelationAuthorizerFilter(pluralBaseNameLower, {
+        operationGroup: OperationGroup.UPDATE,
+        many: true,
+      })
+      modifyRelationsFilter?: ModifyRelationOptions<DTO, Relation>,
     ): Promise<DTO> {
       const { input } = await transformAndValidate(AddArgs, addArgs);
       return this.service.removeRelations(relationName, input.id, input.relationIds, modifyRelationsFilter);

--- a/packages/query-graphql/src/resolvers/relations/update-relations.resolver.ts
+++ b/packages/query-graphql/src/resolvers/relations/update-relations.resolver.ts
@@ -8,6 +8,7 @@ import { transformAndValidate } from '../helpers';
 import { ServiceResolver, BaseServiceResolver } from '../resolver.interface';
 import { flattenRelations, removeRelationOpts } from './helpers';
 import { RelationsOpts, ResolverRelation } from './relations.interface';
+import { OperationGroup } from '../../auth';
 
 const UpdateOneRelationMixin = <DTO, Relation>(DTOClass: Class<DTO>, relation: ResolverRelation<Relation>) => <
   B extends Class<ServiceResolver<DTO, QueryService<DTO, unknown, unknown>>>
@@ -32,7 +33,11 @@ const UpdateOneRelationMixin = <DTO, Relation>(DTOClass: Class<DTO>, relation: R
     })
     async [`set${baseName}On${dtoNames.baseName}`](
       @Args() setArgs: SetArgs,
-      @ModifyRelationAuthorizerFilter(baseNameLower) modifyRelationsFilter?: ModifyRelationOptions<DTO, Relation>,
+      @ModifyRelationAuthorizerFilter(baseNameLower, {
+        operationGroup: OperationGroup.UPDATE,
+        many: false,
+      })
+      modifyRelationsFilter?: ModifyRelationOptions<DTO, Relation>,
     ): Promise<DTO> {
       const { input } = await transformAndValidate(SetArgs, setArgs);
       return this.service.setRelation(relationName, input.id, input.relationId, modifyRelationsFilter);
@@ -64,7 +69,11 @@ const UpdateManyRelationMixin = <DTO, Relation>(DTOClass: Class<DTO>, relation: 
     })
     async [`add${pluralBaseName}To${dtoNames.baseName}`](
       @Args() addArgs: AddArgs,
-      @ModifyRelationAuthorizerFilter(pluralBaseNameLower) modifyRelationsFilter?: ModifyRelationOptions<DTO, Relation>,
+      @ModifyRelationAuthorizerFilter(pluralBaseNameLower, {
+        operationGroup: OperationGroup.UPDATE,
+        many: true,
+      })
+      modifyRelationsFilter?: ModifyRelationOptions<DTO, Relation>,
     ): Promise<DTO> {
       const { input } = await transformAndValidate(AddArgs, addArgs);
       return this.service.addRelations(relationName, input.id, input.relationIds, modifyRelationsFilter);

--- a/packages/query-graphql/src/resolvers/update.resolver.ts
+++ b/packages/query-graphql/src/resolvers/update.resolver.ts
@@ -25,6 +25,7 @@ import { BaseServiceResolver, ResolverClass, ServiceResolver, SubscriptionResolv
 import { AuthorizerFilter, MutationHookArgs, ResolverMutation, ResolverSubscription } from '../decorators';
 import { createSubscriptionFilter } from './helpers';
 import { AuthorizerInterceptor, HookInterceptor } from '../interceptors';
+import { OperationGroup } from '../auth';
 
 export type UpdatedEvent<DTO> = { [eventName: string]: DTO };
 export interface UpdateResolverOpts<DTO, U = DeepPartial<DTO>> extends SubscriptionResolverOpts {
@@ -142,7 +143,14 @@ export const Updateable = <DTO, U, QS extends QueryService<DTO, unknown, U>>(
       commonResolverOpts,
       opts.one ?? {},
     )
-    async updateOne(@MutationHookArgs() input: UO, @AuthorizerFilter() authorizeFilter?: Filter<DTO>): Promise<DTO> {
+    async updateOne(
+      @MutationHookArgs() input: UO,
+      @AuthorizerFilter({
+        operationGroup: OperationGroup.UPDATE,
+        many: false,
+      })
+      authorizeFilter?: Filter<DTO>,
+    ): Promise<DTO> {
       const { id, update } = input.input;
       const updateResult = await this.service.updateOne(id, update, { filter: authorizeFilter ?? {} });
       if (enableOneSubscriptions) {
@@ -165,7 +173,11 @@ export const Updateable = <DTO, U, QS extends QueryService<DTO, unknown, U>>(
     )
     async updateMany(
       @MutationHookArgs() input: UM,
-      @AuthorizerFilter() authorizeFilter?: Filter<DTO>,
+      @AuthorizerFilter({
+        operationGroup: OperationGroup.UPDATE,
+        many: true,
+      })
+      authorizeFilter?: Filter<DTO>,
     ): Promise<UpdateManyResponse> {
       const { update, filter } = input.input;
       const updateManyResponse = await this.service.updateMany(update, mergeFilter(filter, authorizeFilter ?? {}));


### PR DESCRIPTION
Hey Doug,
here's a pull request that adds the primary feature requested in #1026.
I'm looking forward to your feedback.

**Contents**
- Updated `Authorizer` interface to also receive an `operationName` (optional Argument to keep backwards compatibility)
- Updated `DefaultCrudAuthorizer` and `AuthorizerOptions` to also pass along the `operationName` argument.
- Updated `AuthorizerFilter`, `RelationAuthorizerFilter` and `ModifyRelationAuthorizerFilter` to pass the name of the annotated method as `operationName` to the `Authorizer`. This name can also be overriden by a new optional argument `operationName` that was added to those decorators.
- Used this override on `queryMany` of the `ReadResolver` to change the passed name to `query` to better align with the names of the query service.
- Updated the auth-example to show new possibilities using the `nestjs-query-3` - user. Modified the example so that this user can read and aggregate all todos of all users but only update/delete his own todos
- Added two new unit tests that check if the `operationName` parameter gets passed correctly
- Extended documentation on authorization  based on operation names

**Unimplemented parts of the feature request**
- Does not pass the user input/args to the authorizer because this would require deeper changes and might overcomplicate things. Might be better to perform such checks using custom validators instead.
- Authorization on `create*` methods. This should be the scope of a new issue/PR. Main use case would be to throw an Unauthorized here if a user isn't authorized. The filters returned by the authorizers may not be needed for creation. (But maybe could be checked against the input but this would be more related to validation again).