### PR TITLE
 fix(graphql,federation,#1051): Fix error when using nullable reference in federation

### DIFF
--- a/examples/federation/graphql-gateway/src/app.module.ts
+++ b/examples/federation/graphql-gateway/src/app.module.ts
@@ -13,6 +13,7 @@ import { GraphQLGatewayModule } from '@nestjs/graphql';
           { name: 'todo-items', url: 'http://localhost:3001/graphql' },
           { name: 'sub-tasks', url: 'http://localhost:3002/graphql' },
           { name: 'tags', url: 'http://localhost:3003/graphql' },
+          { name: 'user', url: 'http://localhost:3004/graphql' },
         ],
       },
     }),

--- a/examples/federation/todo-item-graphql/e2e/fixtures.ts
+++ b/examples/federation/todo-item-graphql/e2e/fixtures.ts
@@ -10,9 +10,9 @@ export const refresh = async (connection: Connection): Promise<void> => {
 
   const todoRepo = connection.getRepository(TodoItemEntity);
   await todoRepo.save([
-    { title: 'Create Nest App', completed: true },
-    { title: 'Create Entity', completed: false },
-    { title: 'Create Entity Service', completed: false },
+    { title: 'Create Nest App', completed: true, assigneeId: 1 },
+    { title: 'Create Entity', completed: false, assigneeId: 2 },
+    { title: 'Create Entity Service', completed: false, assigneeId: 3 },
     { title: 'Add Todo Item Resolver', completed: false },
     { title: 'How to create item With Sub Tasks', completed: false },
   ]);

--- a/examples/federation/todo-item-graphql/src/todo-item/dto/todo-item-input.dto.ts
+++ b/examples/federation/todo-item-graphql/src/todo-item/dto/todo-item-input.dto.ts
@@ -1,5 +1,5 @@
-import { IsString, MaxLength, IsBoolean } from 'class-validator';
-import { Field, InputType } from '@nestjs/graphql';
+import { IsString, MaxLength, IsBoolean, IsOptional } from 'class-validator';
+import { Field, ID, InputType } from '@nestjs/graphql';
 
 @InputType('TodoItemInput')
 export class TodoItemInputDTO {
@@ -11,4 +11,8 @@ export class TodoItemInputDTO {
   @IsBoolean()
   @Field()
   completed!: boolean;
+
+  @IsOptional()
+  @Field(() => ID, { nullable: true })
+  assigneeId?: number;
 }

--- a/examples/federation/todo-item-graphql/src/todo-item/dto/todo-item-update.dto.ts
+++ b/examples/federation/todo-item-graphql/src/todo-item/dto/todo-item-update.dto.ts
@@ -1,5 +1,5 @@
 import { IsString, MaxLength, IsBoolean, IsOptional } from 'class-validator';
-import { Field, InputType } from '@nestjs/graphql';
+import { Field, ID, InputType } from '@nestjs/graphql';
 
 @InputType('TodoItemUpdate')
 export class TodoItemUpdateDTO {
@@ -13,4 +13,8 @@ export class TodoItemUpdateDTO {
   @IsBoolean()
   @Field({ nullable: true })
   completed?: boolean;
+
+  @IsOptional()
+  @Field(() => ID, { nullable: true })
+  assigneeId?: number;
 }

--- a/examples/federation/todo-item-graphql/src/todo-item/dto/todo-item.dto.ts
+++ b/examples/federation/todo-item-graphql/src/todo-item/dto/todo-item.dto.ts
@@ -1,8 +1,10 @@
-import { FilterableField } from '@nestjs-query/query-graphql';
+import { FilterableField, Reference } from '@nestjs-query/query-graphql';
 import { ObjectType, ID, GraphQLISODateTime, Directive } from '@nestjs/graphql';
+import { UserReferenceDTO } from './user-reference.dto';
 
 @ObjectType('TodoItem')
 @Directive('@key(fields: "id")')
+@Reference('assignee', () => UserReferenceDTO, { id: 'assigneeId' }, { nullable: true })
 export class TodoItemDTO {
   @FilterableField(() => ID)
   id!: number;
@@ -15,6 +17,9 @@ export class TodoItemDTO {
 
   @FilterableField()
   completed!: boolean;
+
+  @FilterableField({ nullable: true })
+  assigneeId?: string;
 
   @FilterableField(() => GraphQLISODateTime)
   created!: Date;

--- a/examples/federation/todo-item-graphql/src/todo-item/dto/user-reference.dto.ts
+++ b/examples/federation/todo-item-graphql/src/todo-item/dto/user-reference.dto.ts
@@ -1,0 +1,10 @@
+import { ObjectType, Directive, Field, ID } from '@nestjs/graphql';
+
+@ObjectType('User')
+@Directive('@extends')
+@Directive('@key(fields: "id")')
+export class UserReferenceDTO {
+  @Field(() => ID)
+  @Directive('@external')
+  id!: number;
+}

--- a/examples/federation/user-graphql/e2e/fixtures.ts
+++ b/examples/federation/user-graphql/e2e/fixtures.ts
@@ -1,0 +1,17 @@
+import { Connection } from 'typeorm';
+import { UserEntity } from '../src/user/user.entity';
+import { executeTruncate } from '../../../helpers';
+
+const tables = ['user'];
+export const truncate = async (connection: Connection): Promise<void> => executeTruncate(connection, tables);
+
+export const refresh = async (connection: Connection): Promise<void> => {
+  await truncate(connection);
+
+  const userRepo = connection.getRepository(UserEntity);
+  await userRepo.save([
+    { name: 'User 1', email: 'user1@example.com' },
+    { name: 'User 2', email: 'user2@example.com' },
+    { name: 'User 3', email: 'user3@example.com' },
+  ]);
+};

--- a/examples/federation/user-graphql/e2e/graphql-fragments.ts
+++ b/examples/federation/user-graphql/e2e/graphql-fragments.ts
@@ -1,0 +1,23 @@
+export const userFields = `
+    id
+    name
+    email
+  `;
+
+export const pageInfoField = `
+pageInfo{
+  hasNextPage
+  hasPreviousPage
+  startCursor
+  endCursor
+}
+`;
+
+export const edgeNodes = (fields: string): string => `
+  edges {
+    node{
+      ${fields}    
+    }
+    cursor
+  }  
+  `;

--- a/examples/federation/user-graphql/e2e/user.resolver.spec.ts
+++ b/examples/federation/user-graphql/e2e/user.resolver.spec.ts
@@ -4,11 +4,11 @@ import request from 'supertest';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Connection } from 'typeorm';
 import { AppModule } from '../src/app.module';
-import { TodoItemDTO } from '../src/todo-item/dto/todo-item.dto';
+import { UserDTO } from '../src/user/dto/user.dto';
 import { refresh } from './fixtures';
-import { edgeNodes, pageInfoField, todoItemFields } from './graphql-fragments';
+import { edgeNodes, pageInfoField, userFields } from './graphql-fragments';
 
-describe('Federated - TodoItemResolver (e2e)', () => {
+describe('Federated - UserResolver (e2e)', () => {
   let app: INestApplication;
 
   beforeAll(async () => {
@@ -34,15 +34,15 @@ describe('Federated - TodoItemResolver (e2e)', () => {
   afterAll(() => refresh(app.get(Connection)));
 
   describe('find one', () => {
-    it(`should find a todo item by id`, () =>
+    it(`should find a user by id`, () =>
       request(app.getHttpServer())
         .post('/graphql')
         .send({
           operationName: null,
           variables: {},
           query: `{
-          todoItem(id: 1) {
-            ${todoItemFields}
+          user(id: 1) {
+            ${userFields}
           }
         }`,
         })
@@ -50,100 +50,30 @@ describe('Federated - TodoItemResolver (e2e)', () => {
         .then(({ body }) => {
           expect(body).toEqual({
             data: {
-              todoItem: {
+              user: {
                 id: '1',
-                title: 'Create Nest App',
-                completed: true,
-                description: null,
+                name: 'User 1',
+                email: 'user1@example.com',
               },
             },
           });
         }));
 
-    it(`should find a todo and assignee`, () =>
+    it(`should return null if the user is not found`, () =>
       request(app.getHttpServer())
         .post('/graphql')
         .send({
           operationName: null,
           variables: {},
           query: `{
-            todoItem(id: 1) {
-              ${todoItemFields}
-              assigneeId
-              assignee {
-                id
-                __typename
-              }
-            }
-          }`,
-        })
-        .expect(200)
-        .then(({ body }) => {
-          expect(body).toEqual({
-            data: {
-              todoItem: {
-                id: '1',
-                title: 'Create Nest App',
-                completed: true,
-                description: null,
-                assigneeId: '1',
-                assignee: {
-                  id: '1',
-                  __typename: 'User',
-                },
-              },
-            },
-          });
-        }));
-
-    it(`should return null if there is no assignee`, () =>
-      request(app.getHttpServer())
-        .post('/graphql')
-        .send({
-          operationName: null,
-          variables: {},
-          query: `{
-              todoItem(id: 5) {
-                ${todoItemFields}
-                assigneeId
-                assignee {
-                  id
-                  __typename
-                }
-              }
-            }`,
-        })
-        .expect(200)
-        .then(({ body }) => {
-          expect(body).toEqual({
-            data: {
-              todoItem: {
-                id: '5',
-                title: 'How to create item With Sub Tasks',
-                completed: false,
-                description: null,
-                assigneeId: null,
-                assignee: null,
-              },
-            },
-          });
-        }));
-
-    it(`should return null if the todo item is not found`, () =>
-      request(app.getHttpServer())
-        .post('/graphql')
-        .send({
-          operationName: null,
-          variables: {},
-          query: `{
-          todoItem(id: 100) {
-            ${todoItemFields}
+          user(id: 100) {
+            ${userFields}
           }
         }`,
         })
         .expect(200, {
           data: {
-            todoItem: null,
+            user: null,
           },
         }));
   });
@@ -156,28 +86,26 @@ describe('Federated - TodoItemResolver (e2e)', () => {
           operationName: null,
           variables: {},
           query: `{
-          todoItems {
+          users {
             ${pageInfoField}
-            ${edgeNodes(todoItemFields)}
+            ${edgeNodes(userFields)}
           }
         }`,
         })
         .expect(200)
         .then(({ body }) => {
-          const { edges, pageInfo }: CursorConnectionType<TodoItemDTO> = body.data.todoItems;
+          const { edges, pageInfo }: CursorConnectionType<UserDTO> = body.data.users;
           expect(pageInfo).toEqual({
-            endCursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
+            endCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
             hasNextPage: false,
             hasPreviousPage: false,
             startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
           });
-          expect(edges).toHaveLength(5);
+          expect(edges).toHaveLength(3);
           expect(edges.map((e) => e.node)).toEqual([
-            { id: '1', title: 'Create Nest App', completed: true, description: null },
-            { id: '2', title: 'Create Entity', completed: false, description: null },
-            { id: '3', title: 'Create Entity Service', completed: false, description: null },
-            { id: '4', title: 'Add Todo Item Resolver', completed: false, description: null },
-            { id: '5', title: 'How to create item With Sub Tasks', completed: false, description: null },
+            { id: '1', name: 'User 1', email: 'user1@example.com' },
+            { id: '2', name: 'User 2', email: 'user2@example.com' },
+            { id: '3', name: 'User 3', email: 'user3@example.com' },
           ]);
         }));
 
@@ -188,26 +116,25 @@ describe('Federated - TodoItemResolver (e2e)', () => {
           operationName: null,
           variables: {},
           query: `{
-          todoItems(filter: { id: { in: [1, 2, 3] } }) {
+          users(filter: { id: { in: [1, 2] } }) {
             ${pageInfoField}
-            ${edgeNodes(todoItemFields)}
+            ${edgeNodes(userFields)}
           }
         }`,
         })
         .expect(200)
         .then(({ body }) => {
-          const { edges, pageInfo }: CursorConnectionType<TodoItemDTO> = body.data.todoItems;
+          const { edges, pageInfo }: CursorConnectionType<UserDTO> = body.data.users;
           expect(pageInfo).toEqual({
-            endCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
+            endCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
             hasNextPage: false,
             hasPreviousPage: false,
             startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
           });
-          expect(edges).toHaveLength(3);
+          expect(edges).toHaveLength(2);
           expect(edges.map((e) => e.node)).toEqual([
-            { id: '1', title: 'Create Nest App', completed: true, description: null },
-            { id: '2', title: 'Create Entity', completed: false, description: null },
-            { id: '3', title: 'Create Entity Service', completed: false, description: null },
+            { id: '1', name: 'User 1', email: 'user1@example.com' },
+            { id: '2', name: 'User 2', email: 'user2@example.com' },
           ]);
         }));
 
@@ -218,28 +145,26 @@ describe('Federated - TodoItemResolver (e2e)', () => {
           operationName: null,
           variables: {},
           query: `{
-          todoItems(sorting: [{field: id, direction: DESC}]) {
+          users(sorting: [{field: id, direction: DESC}]) {
             ${pageInfoField}
-            ${edgeNodes(todoItemFields)}
+            ${edgeNodes(userFields)}
           }
         }`,
         })
         .expect(200)
         .then(({ body }) => {
-          const { edges, pageInfo }: CursorConnectionType<TodoItemDTO> = body.data.todoItems;
+          const { edges, pageInfo }: CursorConnectionType<UserDTO> = body.data.users;
           expect(pageInfo).toEqual({
-            endCursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
+            endCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
             hasNextPage: false,
             hasPreviousPage: false,
             startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
           });
-          expect(edges).toHaveLength(5);
+          expect(edges).toHaveLength(3);
           expect(edges.map((e) => e.node)).toEqual([
-            { id: '5', title: 'How to create item With Sub Tasks', completed: false, description: null },
-            { id: '4', title: 'Add Todo Item Resolver', completed: false, description: null },
-            { id: '3', title: 'Create Entity Service', completed: false, description: null },
-            { id: '2', title: 'Create Entity', completed: false, description: null },
-            { id: '1', title: 'Create Nest App', completed: true, description: null },
+            { id: '3', name: 'User 3', email: 'user3@example.com' },
+            { id: '2', name: 'User 2', email: 'user2@example.com' },
+            { id: '1', name: 'User 1', email: 'user1@example.com' },
           ]);
         }));
 
@@ -251,15 +176,15 @@ describe('Federated - TodoItemResolver (e2e)', () => {
             operationName: null,
             variables: {},
             query: `{
-          todoItems(paging: {first: 2}) {
+              users(paging: {first: 2}) {
             ${pageInfoField}
-            ${edgeNodes(todoItemFields)}
+            ${edgeNodes(userFields)}
           }
         }`,
           })
           .expect(200)
           .then(({ body }) => {
-            const { edges, pageInfo }: CursorConnectionType<TodoItemDTO> = body.data.todoItems;
+            const { edges, pageInfo }: CursorConnectionType<UserDTO> = body.data.users;
             expect(pageInfo).toEqual({
               endCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
               hasNextPage: true,
@@ -268,8 +193,8 @@ describe('Federated - TodoItemResolver (e2e)', () => {
             });
             expect(edges).toHaveLength(2);
             expect(edges.map((e) => e.node)).toEqual([
-              { id: '1', title: 'Create Nest App', completed: true, description: null },
-              { id: '2', title: 'Create Entity', completed: false, description: null },
+              { id: '1', name: 'User 1', email: 'user1@example.com' },
+              { id: '2', name: 'User 2', email: 'user2@example.com' },
             ]);
           }));
 
@@ -280,166 +205,166 @@ describe('Federated - TodoItemResolver (e2e)', () => {
             operationName: null,
             variables: {},
             query: `{
-          todoItems(paging: {first: 2, after: "YXJyYXljb25uZWN0aW9uOjE="}) {
+          users(paging: {first: 2, after: "YXJyYXljb25uZWN0aW9uOjA="}) {
             ${pageInfoField}
-            ${edgeNodes(todoItemFields)}
+            ${edgeNodes(userFields)}
           }
         }`,
           })
           .expect(200)
           .then(({ body }) => {
-            const { edges, pageInfo }: CursorConnectionType<TodoItemDTO> = body.data.todoItems;
+            const { edges, pageInfo }: CursorConnectionType<UserDTO> = body.data.users;
             expect(pageInfo).toEqual({
-              endCursor: 'YXJyYXljb25uZWN0aW9uOjM=',
-              hasNextPage: true,
+              endCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
+              hasNextPage: false,
               hasPreviousPage: true,
-              startCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
+              startCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
             });
             expect(edges).toHaveLength(2);
             expect(edges.map((e) => e.node)).toEqual([
-              { id: '3', title: 'Create Entity Service', completed: false, description: null },
-              { id: '4', title: 'Add Todo Item Resolver', completed: false, description: null },
+              { id: '2', name: 'User 2', email: 'user2@example.com' },
+              { id: '3', name: 'User 3', email: 'user3@example.com' },
             ]);
           }));
     });
   });
 
   describe('create one', () => {
-    it('should allow creating a todoItem', () =>
+    it('should allow creating a user', () =>
       request(app.getHttpServer())
         .post('/graphql')
         .send({
           operationName: null,
           variables: {},
           query: `mutation {
-            createOneTodoItem(
+            createOneUser(
               input: {
-                todoItem: { title: "Test Todo", completed: false }
+                user: { name: "User 4", email: "user4@example.com" }
               }
             ) {
               id
-              title
-              completed
+              name
+              email
             }
         }`,
         })
         .expect(200, {
           data: {
-            createOneTodoItem: {
-              id: '6',
-              title: 'Test Todo',
-              completed: false,
+            createOneUser: {
+              id: '4',
+              name: 'User 4',
+              email: 'user4@example.com',
             },
           },
         }));
 
-    it('should validate a todoItem', () =>
+    it('should validate a user', () =>
       request(app.getHttpServer())
         .post('/graphql')
         .send({
           operationName: null,
           variables: {},
           query: `mutation {
-            createOneTodoItem(
+            createOneUser(
               input: {
-                todoItem: { title: "Test Todo with a too long title!", completed: false }
+                user: { name: "User 5", email: "This is not a valid email" }
               }
             ) {
               id
-              title
-              completed
+              name
+              email
             }
         }`,
         })
         .expect(200)
         .then(({ body }) => {
           expect(body.errors).toHaveLength(1);
-          expect(JSON.stringify(body.errors[0])).toContain('title must be shorter than or equal to 20 characters');
+          expect(JSON.stringify(body.errors[0])).toContain('email must be an email');
         }));
   });
 
   describe('create many', () => {
-    it('should allow creating a todoItem', () =>
+    it('should allow creating a user', () =>
       request(app.getHttpServer())
         .post('/graphql')
         .send({
           operationName: null,
           variables: {},
           query: `mutation {
-            createManyTodoItems(
+            createManyUsers(
               input: {
-                todoItems: [
-                  { title: "Many Test Todo 1", completed: false },
-                  { title: "Many Test Todo 2", completed: true }
+                users: [
+                  { name: "User 5", email: "user5@example.com" },
+                  { name: "User 6", email: "user6@example.com" }
                 ]
               }
             ) {
               id
-              title
-              completed
+              name
+              email
             }
         }`,
         })
         .expect(200, {
           data: {
-            createManyTodoItems: [
-              { id: '7', title: 'Many Test Todo 1', completed: false },
-              { id: '8', title: 'Many Test Todo 2', completed: true },
+            createManyUsers: [
+              { id: '5', name: 'User 5', email: 'user5@example.com' },
+              { id: '6', name: 'User 6', email: 'user6@example.com' },
             ],
           },
         }));
 
-    it('should validate a todoItem', () =>
+    it('should validate a user', () =>
       request(app.getHttpServer())
         .post('/graphql')
         .send({
           operationName: null,
           variables: {},
           query: `mutation {
-            createManyTodoItems(
+            createManyUsers(
               input: {
-                todoItems: [{ title: "Test Todo With A Really Long Title", completed: false }]
+                users: [{ name: "User 7", email: "This is not a valid email" }]
               }
             ) {
               id
-              title
-              completed
+              name
+              email
             }
         }`,
         })
         .expect(200)
         .then(({ body }) => {
           expect(body.errors).toHaveLength(1);
-          expect(JSON.stringify(body.errors[0])).toContain('title must be shorter than or equal to 20 characters');
+          expect(JSON.stringify(body.errors[0])).toContain('email must be an email');
         }));
   });
 
   describe('update one', () => {
-    it('should allow updating a todoItem', () =>
+    it('should allow updating a user', () =>
       request(app.getHttpServer())
         .post('/graphql')
         .send({
           operationName: null,
           variables: {},
           query: `mutation {
-            updateOneTodoItem(
+            updateOneUser(
               input: {
                 id: "6",
-                update: { title: "Update Test Todo", completed: true }
+                update: { name: "User 6a", email: "user6a@example.com" }
               }
             ) {
               id
-              title
-              completed
+              name
+              email
             }
         }`,
         })
         .expect(200, {
           data: {
-            updateOneTodoItem: {
+            updateOneUser: {
               id: '6',
-              title: 'Update Test Todo',
-              completed: true,
+              name: 'User 6a',
+              email: 'user6a@example.com',
             },
           },
         }));
@@ -451,23 +376,21 @@ describe('Federated - TodoItemResolver (e2e)', () => {
           operationName: null,
           variables: {},
           query: `mutation {
-            updateOneTodoItem(
+            updateOneUser(
               input: {
-                update: { title: "Update Test Todo With A Really Long Title" }
+                update: { name: "User X" }
               }
             ) {
               id
-              title
-              completed
+              name
+              email
             }
         }`,
         })
         .expect(400)
         .then(({ body }) => {
           expect(body.errors).toHaveLength(1);
-          expect(body.errors[0].message).toBe(
-            'Field "UpdateOneTodoItemInput.id" of required type "ID!" was not provided.',
-          );
+          expect(body.errors[0].message).toBe('Field "UpdateOneUserInput.id" of required type "ID!" was not provided.');
         }));
 
     it('should validate an update', () =>
@@ -477,37 +400,37 @@ describe('Federated - TodoItemResolver (e2e)', () => {
           operationName: null,
           variables: {},
           query: `mutation {
-            updateOneTodoItem(
+            updateOneUser(
               input: {
                 id: "6",
-                update: { title: "Update Test Todo With A Really Long Title" }
+                update: { email: "This is not a valid email address" }
               }
             ) {
               id
-              title
-              completed
+              name
+              email
             }
         }`,
         })
         .expect(200)
         .then(({ body }) => {
           expect(body.errors).toHaveLength(1);
-          expect(JSON.stringify(body.errors[0])).toContain('title must be shorter than or equal to 20 characters');
+          expect(JSON.stringify(body.errors[0])).toContain('email must be an email');
         }));
   });
 
   describe('update many', () => {
-    it('should allow updating a todoItem', () =>
+    it('should allow updating a user', () =>
       request(app.getHttpServer())
         .post('/graphql')
         .send({
           operationName: null,
           variables: {},
           query: `mutation {
-            updateManyTodoItems(
+            updateManyUsers(
               input: {
-                filter: {id: { in: ["7", "8"]} },
-                update: { title: "Update Many Test", completed: true }
+                filter: {id: { in: ["5", "6"]} },
+                update: { name: "New Users" }
               }
             ) {
               updatedCount
@@ -516,7 +439,7 @@ describe('Federated - TodoItemResolver (e2e)', () => {
         })
         .expect(200, {
           data: {
-            updateManyTodoItems: {
+            updateManyUsers: {
               updatedCount: 2,
             },
           },
@@ -529,9 +452,9 @@ describe('Federated - TodoItemResolver (e2e)', () => {
           operationName: null,
           variables: {},
           query: `mutation {
-            updateManyTodoItems(
+            updateManyUsers(
               input: {
-                update: { title: "Update Many Test", completed: true }
+                update: { name: "New users" }
               }
             ) {
               updatedCount
@@ -542,7 +465,7 @@ describe('Federated - TodoItemResolver (e2e)', () => {
         .then(({ body }) => {
           expect(body.errors).toHaveLength(1);
           expect(body.errors[0].message).toBe(
-            'Field "UpdateManyTodoItemsInput.filter" of required type "TodoItemUpdateFilter!" was not provided.',
+            'Field "UpdateManyUsersInput.filter" of required type "UserUpdateFilter!" was not provided.',
           );
         }));
 
@@ -553,10 +476,10 @@ describe('Federated - TodoItemResolver (e2e)', () => {
           operationName: null,
           variables: {},
           query: `mutation {
-            updateManyTodoItems(
+            updateManyUsers(
               input: {
                 filter: { },
-                update: { title: "Update Many Test", completed: true }
+                update: { name: "New users" }
               }
             ) {
               updatedCount
@@ -571,28 +494,28 @@ describe('Federated - TodoItemResolver (e2e)', () => {
   });
 
   describe('delete one', () => {
-    it('should allow deleting a todoItem', () =>
+    it('should allow deleting a user', () =>
       request(app.getHttpServer())
         .post('/graphql')
         .send({
           operationName: null,
           variables: {},
           query: `mutation {
-            deleteOneTodoItem(
+            deleteOneUser(
               input: { id: "6" }
             ) {
               id
-              title
-              completed
+              name
+              email
             }
         }`,
         })
         .expect(200, {
           data: {
-            deleteOneTodoItem: {
+            deleteOneUser: {
               id: null,
-              title: 'Update Test Todo',
-              completed: true,
+              name: 'New Users',
+              email: 'user6a@example.com',
             },
           },
         }));
@@ -604,12 +527,12 @@ describe('Federated - TodoItemResolver (e2e)', () => {
           operationName: null,
           variables: {},
           query: `mutation {
-            deleteOneTodoItem(
+            deleteOneUser(
               input: { }
             ) {
               id
-              title
-              completed
+              name
+              email
             }
         }`,
         })
@@ -621,16 +544,16 @@ describe('Federated - TodoItemResolver (e2e)', () => {
   });
 
   describe('delete many', () => {
-    it('should allow updating a todoItem', () =>
+    it('should allow deleting a user', () =>
       request(app.getHttpServer())
         .post('/graphql')
         .send({
           operationName: null,
           variables: {},
           query: `mutation {
-            deleteManyTodoItems(
+            deleteManyUsers(
               input: {
-                filter: {id: { in: ["7", "8"]} },
+                filter: {id: { in: ["4", "5"]} },
               }
             ) {
               deletedCount
@@ -639,7 +562,7 @@ describe('Federated - TodoItemResolver (e2e)', () => {
         })
         .expect(200, {
           data: {
-            deleteManyTodoItems: {
+            deleteManyUsers: {
               deletedCount: 2,
             },
           },
@@ -652,7 +575,7 @@ describe('Federated - TodoItemResolver (e2e)', () => {
           operationName: null,
           variables: {},
           query: `mutation {
-            deleteManyTodoItems(
+            deleteManyUsers(
               input: { }
             ) {
               deletedCount
@@ -663,7 +586,7 @@ describe('Federated - TodoItemResolver (e2e)', () => {
         .then(({ body }) => {
           expect(body.errors).toHaveLength(1);
           expect(body.errors[0].message).toBe(
-            'Field "DeleteManyTodoItemsInput.filter" of required type "TodoItemDeleteFilter!" was not provided.',
+            'Field "DeleteManyUsersInput.filter" of required type "UserDeleteFilter!" was not provided.',
           );
         }));
 
@@ -674,7 +597,7 @@ describe('Federated - TodoItemResolver (e2e)', () => {
           operationName: null,
           variables: {},
           query: `mutation {
-            deleteManyTodoItems(
+            deleteManyUsers(
               input: {
                 filter: { },
               }

--- a/examples/federation/user-graphql/src/app.module.ts
+++ b/examples/federation/user-graphql/src/app.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { GraphQLFederationModule } from '@nestjs/graphql';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { typeormOrmConfig } from '../../../helpers';
+import { UserModule } from './user/user.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot(typeormOrmConfig('federation_user')),
+    GraphQLFederationModule.forRoot({
+      autoSchemaFile: 'schema.gql',
+    }),
+    UserModule,
+  ],
+})
+export class AppModule {}

--- a/examples/federation/user-graphql/src/main.ts
+++ b/examples/federation/user-graphql/src/main.ts
@@ -1,0 +1,22 @@
+import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
+import { AppModule } from './app.module';
+
+async function bootstrap(): Promise<void> {
+  const app = await NestFactory.create(AppModule);
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      skipMissingProperties: false,
+      forbidUnknownValues: true,
+    }),
+  );
+
+  await app.listen(3004);
+}
+
+// eslint-disable-next-line no-void
+void bootstrap();

--- a/examples/federation/user-graphql/src/user/dto/user-input.dto.ts
+++ b/examples/federation/user-graphql/src/user/dto/user-input.dto.ts
@@ -1,0 +1,14 @@
+import { IsEmail, IsString, MaxLength } from 'class-validator';
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType('UserInput')
+export class UserInputDTO {
+  @IsString()
+  @MaxLength(50)
+  @Field()
+  name!: string;
+
+  @IsEmail()
+  @Field()
+  email!: string;
+}

--- a/examples/federation/user-graphql/src/user/dto/user-update.dto.ts
+++ b/examples/federation/user-graphql/src/user/dto/user-update.dto.ts
@@ -1,0 +1,16 @@
+import { IsString, MaxLength, IsOptional, IsEmail } from 'class-validator';
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType('UserUpdate')
+export class UserUpdateDTO {
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  @Field({ nullable: true })
+  name?: string;
+
+  @IsOptional()
+  @IsEmail()
+  @Field({ nullable: true })
+  email?: string;
+}

--- a/examples/federation/user-graphql/src/user/dto/user.dto.ts
+++ b/examples/federation/user-graphql/src/user/dto/user.dto.ts
@@ -1,0 +1,21 @@
+import { FilterableField } from '@nestjs-query/query-graphql';
+import { ObjectType, ID, GraphQLISODateTime, Directive } from '@nestjs/graphql';
+
+@ObjectType('User')
+@Directive('@key(fields: "id")')
+export class UserDTO {
+  @FilterableField(() => ID)
+  id!: number;
+
+  @FilterableField()
+  name!: string;
+
+  @FilterableField()
+  email!: string;
+
+  @FilterableField(() => GraphQLISODateTime)
+  created!: Date;
+
+  @FilterableField(() => GraphQLISODateTime)
+  updated!: Date;
+}

--- a/examples/federation/user-graphql/src/user/user.entity.ts
+++ b/examples/federation/user-graphql/src/user/user.entity.ts
@@ -1,21 +1,15 @@
 import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
 
-@Entity({ name: 'todo_item' })
-export class TodoItemEntity {
+@Entity({ name: 'user' })
+export class UserEntity {
   @PrimaryGeneratedColumn()
   id!: number;
 
   @Column()
-  title!: string;
-
-  @Column({ nullable: true })
-  description?: string;
+  name!: string;
 
   @Column()
-  completed!: boolean;
-
-  @Column({ nullable: true })
-  assigneeId?: number;
+  email!: string;
 
   @CreateDateColumn()
   created!: Date;

--- a/examples/federation/user-graphql/src/user/user.module.ts
+++ b/examples/federation/user-graphql/src/user/user.module.ts
@@ -1,0 +1,25 @@
+import { NestjsQueryGraphQLModule } from '@nestjs-query/query-graphql';
+import { NestjsQueryTypeOrmModule } from '@nestjs-query/query-typeorm';
+import { Module } from '@nestjs/common';
+import { UserInputDTO } from './dto/user-input.dto';
+import { UserUpdateDTO } from './dto/user-update.dto';
+import { UserDTO } from './dto/user.dto';
+import { UserEntity } from './user.entity';
+
+@Module({
+  imports: [
+    NestjsQueryGraphQLModule.forFeature({
+      imports: [NestjsQueryTypeOrmModule.forFeature([UserEntity])],
+      resolvers: [
+        {
+          DTOClass: UserDTO,
+          EntityClass: UserEntity,
+          CreateDTOClass: UserInputDTO,
+          UpdateDTOClass: UserUpdateDTO,
+          referenceBy: { key: 'id' },
+        },
+      ],
+    }),
+  ],
+})
+export class UserModule {}

--- a/examples/init-scripts/mysql/init-federation.sql
+++ b/examples/init-scripts/mysql/init-federation.sql
@@ -9,3 +9,7 @@ GRANT ALL PRIVILEGES ON federation_tag.* TO federation_tag;
 CREATE USER federation_todo_item;
 CREATE DATABASE federation_todo_item;
 GRANT ALL PRIVILEGES ON federation_todo_item.* TO federation_todo_item;
+
+CREATE USER federation_user;
+CREATE DATABASE federation_user;
+GRANT ALL PRIVILEGES ON federation_user.* TO federation_user;

--- a/examples/init-scripts/postgres/init-federation.sql
+++ b/examples/init-scripts/postgres/init-federation.sql
@@ -9,3 +9,7 @@ GRANT ALL PRIVILEGES ON DATABASE federation_tag TO federation_tag;
 CREATE USER federation_todo_item WITH SUPERUSER;
 CREATE DATABASE federation_todo_item;
 GRANT ALL PRIVILEGES ON DATABASE federation_todo_item TO federation_todo_item;
+
+CREATE USER federation_user WITH SUPERUSER;
+CREATE DATABASE federation_user;
+GRANT ALL PRIVILEGES ON DATABASE federation_user TO federation_user;

--- a/examples/nest-cli.json
+++ b/examples/nest-cli.json
@@ -74,6 +74,15 @@
         "tsConfigPath": "./tsconfig.json"
       }
     },
+    "federation:user": {
+      "type": "application",
+      "root": "federation/user-graphql",
+      "entryFile": "main",
+      "sourceRoot": "federation/user-graphql/src",
+      "compilerOptions": {
+        "tsConfigPath": "./tsconfig.json"
+      }
+    },
     "hooks": {
       "type": "application",
       "root": "hooks",

--- a/packages/query-graphql/src/decorators/reference.decorator.ts
+++ b/packages/query-graphql/src/decorators/reference.decorator.ts
@@ -6,14 +6,14 @@ import { BaseResolverOptions } from './resolver-method.decorator';
 import { mergeBaseResolverOpts } from '../common';
 
 const reflector = new ArrayReflector(REFERENCE_KEY);
-export type ReferenceDecoratorOpts<DTO, Relation> = Omit<ResolverRelationReference<DTO, Relation>, 'DTO'>;
+export type ReferenceDecoratorOpts<DTO, Relation> = Omit<ResolverRelationReference<DTO, Relation>, 'DTO' | 'keys'>;
 export type ReferenceTypeFunc<Relation> = () => Class<Relation>;
 
 interface ReferenceDescriptor<DTO, Reference> {
   name: string;
   keys: ReferencesKeys<DTO, Reference>;
   relationTypeFunc: () => Class<Reference>;
-  relationOpts?: Omit<ResolverRelationReference<DTO, Reference>, 'DTO'>;
+  relationOpts?: Omit<ResolverRelationReference<DTO, Reference>, 'DTO' | 'keys'>;
 }
 
 function getReferenceDescriptors<DTO>(DTOClass: Class<DTO>): ReferenceDescriptor<DTO, unknown>[] {

--- a/packages/query-graphql/src/resolvers/relations/references-relation.resolver.ts
+++ b/packages/query-graphql/src/resolvers/relations/references-relation.resolver.ts
@@ -17,8 +17,8 @@ const pluckFields = <DTO, Relation>(dto: DTO, fieldMap: ReferencesKeys<DTO, Rela
 };
 
 const allFieldsAreNull = <Relation>(fields: Partial<Relation>): boolean => {
-  return Object.entries(fields).reduce<boolean>(
-    (previousNull, [, value]) => previousNull && (value === null || value === undefined),
+  return Object.values(fields).reduce<boolean>(
+    (previousNull, value) => previousNull && (value === null || value === undefined),
     true,
   );
 };

--- a/packages/query-graphql/src/resolvers/relations/references-relation.resolver.ts
+++ b/packages/query-graphql/src/resolvers/relations/references-relation.resolver.ts
@@ -17,7 +17,10 @@ const pluckFields = <DTO, Relation>(dto: DTO, fieldMap: ReferencesKeys<DTO, Rela
 };
 
 const allFieldsAreNull = <Relation>(fields: Partial<Relation>): boolean => {
-  return Object.entries(fields).reduce<boolean>((previousNull, [, value]) => previousNull && value === null, true);
+  return Object.entries(fields).reduce<boolean>(
+    (previousNull, [, value]) => previousNull && (value === null || value === undefined),
+    true,
+  );
 };
 
 const ReferencesMixin = <DTO, Relation>(DTOClass: Class<DTO>, reference: ResolverRelationReference<DTO, Relation>) => <


### PR DESCRIPTION
This PR fixes the issue that occurs when using nullable `@Reference`. (#1051)

- omitted `keys` property from `ReferenceDecoratorOpts` (they will be merged anyways)
- Added check to see if all key fields are null and then return null for the whole reference in the resolver instead of the object containing the `__typename` and id fields set to null
- Added Users that can be assigned to TodoItems in the federation example to test nullable references.