### PR TITLE
feat(graphql,#1048): added filter-only option to filterable fields

### DIFF
--- a/documentation/docs/graphql/dtos.mdx
+++ b/documentation/docs/graphql/dtos.mdx
@@ -24,6 +24,8 @@ In addition to the normal field options you can also specify the following optio
 * `filterRequired` - When set to `true` the field will be required whenever a `filter` is used. The `filter` requirement applies to all `read`, `update`, and `delete` endpoints that use a `filter`.
   * The `filterRequired` option is useful when your entity has an index that requires a subset of fields to be used to provide certain level of query performance.
   * **NOTE**: When a field is a required in a filter the default `filter` option is ignored.
+* `filterOnly`- When set to `true`, the field will only appear as `filter` but isn't included as field inside the `ObjectType`.
+  * This option is useful if you want to filter on foreign keys without resolving the relation but you don't want to have the foreign key show up as field in your query type for the DTO. This might be especially useful for [federated relations](./federation.mdx#reference-decorator)
 
 ### Example
 
@@ -110,7 +112,37 @@ export class TodoItemDTO {
   @Field(() => GraphQLISODateTime)
   updated!: Date;
 }
+```
 
+### Example - filterOnly
+
+In the following example the `filterOnly` option is applied to the `assigneeId` field, which makes a query filerable by the id of an assignd user but won't return the `assigneeId` as field.
+
+```ts title="todo-item.dto.ts"
+import { FilterableField } from '@nestjs-query/query-graphql';
+import { ObjectType, ID, GraphQLISODateTime, Field } from '@nestjs/graphql';
+
+@ObjectType('TodoItem')
+@Relation('assignee', () => UserDTO)
+export class TodoItemDTO {
+  @FilterableField(() => ID)
+  id!: string;
+
+  @FilterableField()
+  title!: string;
+
+  @FilterableField()
+  completed!: boolean;
+
+  @FilterableField({ filterOnly: true })
+  assigneeId!: string;
+
+  @Field(() => GraphQLISODateTime)
+  created!: Date;
+
+  @Field(() => GraphQLISODateTime)
+  updated!: Date;
+}
 ```
 
 ## `@QueryOptions`
@@ -163,7 +195,7 @@ By default all results will be limited to 10 records.
 To override the default you can override the default page size by setting the `defaultResultSize` option.
 
 In this example we specify the `defaultResultSize` to 5 which means if a page size is not specified 5 results will be
- returned.
+returned.
 
 ```ts title="todo-item.dto.ts" {5}
 import { FilterableField, QueryOptions } from '@nestjs-query/query-graphql';
@@ -307,7 +339,7 @@ Enabling `totalCount` can be expensive. If your table is large the `totalCount` 
 The `totalCount` field is not eagerly fetched. It will only be executed if the field is queried from the client.
 :::
 
-When using the `CURSOR` (the default) or `OFFSET` paging strategy  you have the option to expose a `totalCount` field to
+When using the `CURSOR` (the default) or `OFFSET` paging strategy you have the option to expose a `totalCount` field to
 allow clients to fetch a total count of records in a connection.
 
 To enable the `totalCount` field for connections set the `enableTotalCount` option to `true` using the
@@ -353,7 +385,7 @@ values={[
 {
   todoItems {
     totalCount
-    pageInfo{
+    pageInfo {
       hasNextPage
       hasPreviousPage
       startCursor

--- a/examples/basic/src/todo-item/dto/todo-item.dto.ts
+++ b/examples/basic/src/todo-item/dto/todo-item.dto.ts
@@ -19,9 +19,9 @@ export class TodoItemDTO {
   @FilterableField()
   completed!: boolean;
 
-  @FilterableField(() => GraphQLISODateTime)
+  @FilterableField(() => GraphQLISODateTime, { filterOnly: true })
   created!: Date;
 
-  @FilterableField(() => GraphQLISODateTime)
+  @FilterableField(() => GraphQLISODateTime, { filterOnly: true })
   updated!: Date;
 }

--- a/packages/query-graphql/__tests__/decorators/filterable-fields.decorator.spec.ts
+++ b/packages/query-graphql/__tests__/decorators/filterable-fields.decorator.spec.ts
@@ -23,6 +23,9 @@ describe('FilterableField decorator', (): void => {
 
       @FilterableField(undefined, { nullable: true })
       numberField?: number;
+
+      @FilterableField({ filterOnly: true })
+      filterOnlyField!: string;
     }
     const fields = getFilterableFields(TestDto);
     expect(fields).toMatchObject([
@@ -40,6 +43,12 @@ describe('FilterableField decorator', (): void => {
         returnTypeFunc: floatReturnFunc,
       },
       { propertyName: 'numberField', target: Number, advancedOptions: { nullable: true }, returnTypeFunc: undefined },
+      {
+        propertyName: 'filterOnlyField',
+        target: String,
+        advancedOptions: { filterOnly: true },
+        returnTypeFunc: undefined,
+      },
     ]);
     expect(fieldSpy).toHaveBeenCalledTimes(4);
     expect(fieldSpy).toHaveBeenNthCalledWith(1);

--- a/packages/query-graphql/src/decorators/filterable-field.decorator.ts
+++ b/packages/query-graphql/src/decorators/filterable-field.decorator.ts
@@ -6,6 +6,7 @@ const reflector = new ArrayReflector(FILTERABLE_FIELD_KEY);
 export type FilterableFieldOptions = {
   allowedComparisons?: FilterComparisonOperators<unknown>[];
   filterRequired?: boolean;
+  filterOnly?: boolean;
 } & FieldOptions;
 
 export interface FilterableFieldDescriptor {
@@ -78,6 +79,11 @@ export function FilterableField(
       returnTypeFunc,
       advancedOptions,
     });
+
+    if (advancedOptions?.filterOnly) {
+      return undefined;
+    }
+
     if (returnTypeFunc) {
       return Field(returnTypeFunc, advancedOptions)(target, propertyName, descriptor);
     }


### PR DESCRIPTION
This PR implements the `filterOnly` feature requested in #1048.

**Contents**
- Added `filterOnly` property to `FilterableFieldOptions`.
- If `filterOnly` is set to true then don't call `Field` decorator inside `@FilterableField`.
- Extended existing unit test to check that `filterOnly` is set as metadata and `Field` is not called
- Added test cases to basic example to check for absence of `filterOnly` fields and presence of those fields as filters
- Added relevant parts to documentation