### PR TITLE
feat(): Set relations

### DIFF
--- a/.run/jest.config.js - mysql.run.xml
+++ b/.run/jest.config.js - mysql.run.xml
@@ -8,6 +8,7 @@
     <jest-options value="--runInBand --coverage" />
     <envs>
       <env name="NESTJS_QUERY_DB_TYPE" value="mysql" />
+      <env name="TZ" value="UTC" />
     </envs>
     <scope-kind value="ALL" />
     <method v="2" />

--- a/.run/jest.config.js.run.xml
+++ b/.run/jest.config.js.run.xml
@@ -6,7 +6,9 @@
     <jest-package value="$PROJECT_DIR$/node_modules/jest" />
     <working-dir value="$PROJECT_DIR$" />
     <jest-options value="--runInBand --coverage" />
-    <envs />
+    <envs>
+      <env name="TZ" value="UTC" />
+    </envs>
     <scope-kind value="ALL" />
     <method v="2" />
   </configuration>

--- a/.run/jest.e2e.config.js - mysql.run.xml
+++ b/.run/jest.e2e.config.js - mysql.run.xml
@@ -8,6 +8,7 @@
     <jest-options value="--runInBand --coverage" />
     <envs>
       <env name="NESTJS_QUERY_DB_TYPE" value="mysql" />
+      <env name="TZ" value="UTC" />
     </envs>
     <scope-kind value="ALL" />
     <method v="2" />

--- a/.run/jest.e2e.config.js.run.xml
+++ b/.run/jest.e2e.config.js.run.xml
@@ -6,7 +6,9 @@
     <jest-package value="$PROJECT_DIR$/node_modules/jest" />
     <working-dir value="$PROJECT_DIR$" />
     <jest-options value="--runInBand --coverage" />
-    <envs />
+    <envs>
+      <env name="TZ" value="UTC" />
+    </envs>
     <scope-kind value="ALL" />
     <method v="2" />
   </configuration>

--- a/.run/jest.unit.config.js.run.xml
+++ b/.run/jest.unit.config.js.run.xml
@@ -17,7 +17,9 @@
     <jest-package value="$PROJECT_DIR$/node_modules/jest" />
     <working-dir value="$PROJECT_DIR$" />
     <jest-options value="--coverage" />
-    <envs />
+    <envs>
+      <env name="TZ" value="UTC" />
+    </envs>
     <scope-kind value="ALL" />
     <method v="2" />
   </configuration>

--- a/documentation/docs/concepts/services.md
+++ b/documentation/docs/concepts/services.md
@@ -185,6 +185,16 @@ Adds relations to a `DTO`
 #### Returns
 The DTO the relations were added to.
 
+### `setRelations`
+Sets relations on a `DTO`
+#### Arguments
+* `relationName: string` - The name of the relation
+* `id: string | number` - The id of the DTO to add the relations to
+* `relationIds: (string | number)[]` - The ids of the relations to set. If the relationIds is empty the all relations will be removed.
+* `opts?: ModifyRelationOptions<DTO, Relation>` - Additional options apply when adding relations
+#### Returns
+The DTO the relations were added to.
+
 ### `setRelation`
 Set a relation on a DTO
 #### Arguments

--- a/examples/sequelize/e2e/todo-item.resolver.spec.ts
+++ b/examples/sequelize/e2e/todo-item.resolver.spec.ts
@@ -1228,6 +1228,86 @@ describe('TodoItemResolver (sequelize - e2e)', () => {
         }));
   });
 
+  describe('setTagsOnTodoItem', () => {
+    it('allow settings tags on a todoItem', () =>
+      request(app.getHttpServer())
+        .post('/graphql')
+        .set(AUTH_HEADER_NAME, config.auth.header)
+        .send({
+          operationName: null,
+          variables: {},
+          query: `mutation {
+            setTagsOnTodoItem(
+              input: {
+                id: 1,
+                relationIds: [1, 2, 3, 4, 5]
+              }
+            ) {
+              id
+              title
+              tags(sorting: [{ field: id, direction: ASC }]) {
+                ${pageInfoField}
+                ${edgeNodes(tagFields)}
+                totalCount
+              }
+            }
+        }`,
+        })
+        .expect(200)
+        .then(({ body }) => {
+          const { edges, pageInfo, totalCount }: CursorConnectionType<TagDTO> = body.data.setTagsOnTodoItem.tags;
+          expect(body.data.setTagsOnTodoItem.id).toBe('1');
+          expect(pageInfo).toEqual({
+            endCursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+          });
+          expect(totalCount).toBe(5);
+          expect(edges).toHaveLength(5);
+          expect(edges.map((e) => e.node.name)).toEqual(['Urgent', 'Home', 'Work', 'Question', 'Blocked']);
+        }));
+
+    it('allow settings tags to a todoItem to an empty array', () =>
+      request(app.getHttpServer())
+        .post('/graphql')
+        .set(AUTH_HEADER_NAME, config.auth.header)
+        .send({
+          operationName: null,
+          variables: {},
+          query: `mutation {
+            setTagsOnTodoItem(
+              input: {
+                id: 1,
+                relationIds: []
+              }
+            ) {
+              id
+              title
+              tags(sorting: [{ field: id, direction: ASC }]) {
+                ${pageInfoField}
+                ${edgeNodes(tagFields)}
+                totalCount
+              }
+            }
+        }`,
+        })
+        .expect(200)
+        .then(({ body }) => {
+          const { edges, pageInfo, totalCount }: CursorConnectionType<TagDTO> = body.data.setTagsOnTodoItem.tags;
+          expect(body.data.setTagsOnTodoItem.id).toBe('1');
+          expect(pageInfo).toEqual({
+            endCursor: null,
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: null,
+          });
+          expect(totalCount).toBe(0);
+          expect(edges).toHaveLength(0);
+          expect(edges.map((e) => e.node.name)).toEqual([]);
+        }));
+  });
+
   afterAll(async () => {
     await app.close();
   });

--- a/examples/typegoose/e2e/todo-item.resolver.spec.ts
+++ b/examples/typegoose/e2e/todo-item.resolver.spec.ts
@@ -1431,6 +1431,86 @@ describe('TodoItemResolver (typegoose - e2e)', () => {
         }));
   });
 
+  describe('setTagsOnTodoItem', () => {
+    it('allow settings tags on a todoItem', () =>
+      request(app.getHttpServer())
+        .post('/graphql')
+        .set(AUTH_HEADER_NAME, config.auth.header)
+        .send({
+          operationName: null,
+          variables: {},
+          query: `mutation {
+            setTagsOnTodoItem(
+              input: {
+                id: ${graphqlIds[0]},
+                relationIds: ["5f74ed2686b2bae7bf4b4aab", "5f74ed2686b2bae7bf4b4aac", "5f74ed2686b2bae7bf4b4aad", "5f74ed2686b2bae7bf4b4aae", "5f74ed2686b2bae7bf4b4aaf"]
+              }
+            ) {
+              id
+              title
+              tags(sorting: [{ field: id, direction: ASC }]) {
+                ${pageInfoField}
+                ${edgeNodes(tagFields)}
+                totalCount
+              }
+            }
+        }`,
+        })
+        .expect(200)
+        .then(({ body }) => {
+          const { edges, pageInfo, totalCount }: CursorConnectionType<TagDTO> = body.data.setTagsOnTodoItem.tags;
+          expect(body.data.setTagsOnTodoItem.id).toBe(todoItemIds[0]);
+          expect(pageInfo).toEqual({
+            endCursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+          });
+          expect(totalCount).toBe(5);
+          expect(edges).toHaveLength(5);
+          expect(edges.map((e) => e.node.name)).toEqual(['Urgent', 'Home', 'Work', 'Question', 'Blocked']);
+        }));
+
+    it('allow settings tags to a todoItem to an empty array', () =>
+      request(app.getHttpServer())
+        .post('/graphql')
+        .set(AUTH_HEADER_NAME, config.auth.header)
+        .send({
+          operationName: null,
+          variables: {},
+          query: `mutation {
+            setTagsOnTodoItem(
+              input: {
+                id: ${graphqlIds[0]},
+                relationIds: []
+              }
+            ) {
+              id
+              title
+              tags(sorting: [{ field: id, direction: ASC }]) {
+                ${pageInfoField}
+                ${edgeNodes(tagFields)}
+                totalCount
+              }
+            }
+        }`,
+        })
+        .expect(200)
+        .then(({ body }) => {
+          const { edges, pageInfo, totalCount }: CursorConnectionType<TagDTO> = body.data.setTagsOnTodoItem.tags;
+          expect(body.data.setTagsOnTodoItem.id).toBe(todoItemIds[0]);
+          expect(pageInfo).toEqual({
+            endCursor: null,
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: null,
+          });
+          expect(totalCount).toBe(0);
+          expect(edges).toHaveLength(0);
+          expect(edges.map((e) => e.node.name)).toEqual([]);
+        }));
+  });
+
   afterAll(async () => {
     await app.close();
   });

--- a/examples/typeorm/e2e/todo-item.resolver.spec.ts
+++ b/examples/typeorm/e2e/todo-item.resolver.spec.ts
@@ -1377,6 +1377,86 @@ describe('TodoItemResolver (typeorm - e2e)', () => {
         }));
   });
 
+  describe('setTagsOnTodoItem', () => {
+    it('allow settings tags on a todoItem', () =>
+      request(app.getHttpServer())
+        .post('/graphql')
+        .set(AUTH_HEADER_NAME, config.auth.header)
+        .send({
+          operationName: null,
+          variables: {},
+          query: `mutation {
+            setTagsOnTodoItem(
+              input: {
+                id: 1,
+                relationIds: [1, 2, 3, 4, 5]
+              }
+            ) {
+              id
+              title
+              tags(sorting: [{ field: id, direction: ASC }]) {
+                ${pageInfoField}
+                ${edgeNodes(tagFields)}
+                totalCount
+              }
+            }
+        }`,
+        })
+        .expect(200)
+        .then(({ body }) => {
+          const { edges, pageInfo, totalCount }: CursorConnectionType<TagDTO> = body.data.setTagsOnTodoItem.tags;
+          expect(body.data.setTagsOnTodoItem.id).toBe('1');
+          expect(pageInfo).toEqual({
+            endCursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
+          });
+          expect(totalCount).toBe(5);
+          expect(edges).toHaveLength(5);
+          expect(edges.map((e) => e.node.name)).toEqual(['Urgent', 'Home', 'Work', 'Question', 'Blocked']);
+        }));
+
+    it('allow settings tags to a todoItem to an empty array', () =>
+      request(app.getHttpServer())
+        .post('/graphql')
+        .set(AUTH_HEADER_NAME, config.auth.header)
+        .send({
+          operationName: null,
+          variables: {},
+          query: `mutation {
+            setTagsOnTodoItem(
+              input: {
+                id: 1,
+                relationIds: []
+              }
+            ) {
+              id
+              title
+              tags(sorting: [{ field: id, direction: ASC }]) {
+                ${pageInfoField}
+                ${edgeNodes(tagFields)}
+                totalCount
+              }
+            }
+        }`,
+        })
+        .expect(200)
+        .then(({ body }) => {
+          const { edges, pageInfo, totalCount }: CursorConnectionType<TagDTO> = body.data.setTagsOnTodoItem.tags;
+          expect(body.data.setTagsOnTodoItem.id).toBe('1');
+          expect(pageInfo).toEqual({
+            endCursor: null,
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: null,
+          });
+          expect(totalCount).toBe(0);
+          expect(edges).toHaveLength(0);
+          expect(edges.map((e) => e.node.name)).toEqual([]);
+        }));
+  });
+
   afterAll(async () => {
     await app.close();
   });

--- a/packages/core/__tests__/services/assembler-query.service.spec.ts
+++ b/packages/core/__tests__/services/assembler-query.service.spec.ts
@@ -362,6 +362,33 @@ describe('AssemblerQueryService', () => {
     });
   });
 
+  describe('setRelations', () => {
+    it('should transform the results for a single entity', () => {
+      const mockQueryService = mock<QueryService<TestEntity>>();
+      const assemblerService = new AssemblerQueryService(new TestAssembler(), instance(mockQueryService));
+      when(mockQueryService.setRelations('test', 1, deepEqual([2]), undefined)).thenResolve({
+        bar: 'baz',
+      });
+
+      return expect(assemblerService.setRelations('test', 1, [2])).resolves.toEqual({ foo: 'baz' });
+    });
+    it('should transform the options and results for a single entity', () => {
+      const mockQueryService = mock<QueryService<TestEntity>>();
+      const assemblerService = new AssemblerQueryService(new TestAssembler(), instance(mockQueryService));
+      when(
+        mockQueryService.setRelations('test', 1, deepEqual([2]), objectContaining({ filter: { bar: { eq: 'bar' } } })),
+      ).thenResolve({
+        bar: 'baz',
+      });
+
+      return expect(
+        assemblerService.setRelations('test', 1, [2], {
+          filter: { foo: { eq: 'bar' } },
+        }),
+      ).resolves.toEqual({ foo: 'baz' });
+    });
+  });
+
   describe('removeRelations', () => {
     it('should transform the results for a single entity', () => {
       const mockQueryService = mock<QueryService<TestEntity>>();

--- a/packages/core/__tests__/services/noop-query.service.spec.ts
+++ b/packages/core/__tests__/services/noop-query.service.spec.ts
@@ -12,22 +12,31 @@ describe('NoOpQueryService', () => {
     DeepPartial<TestType>,
     DeepPartial<TestType>
   >();
+
   it('should throw a NotImplementedException when calling addRelations', () =>
     expect(instance.addRelations('test', 1, [1, 2, 3])).rejects.toThrow('addRelations is not implemented'));
+
   it('should throw a NotImplementedException when calling createMany', () =>
     expect(instance.createMany([{ foo: 'bar' }])).rejects.toThrow('createMany is not implemented'));
+
   it('should throw a NotImplementedException when calling createOne', () =>
     expect(instance.createOne({ foo: 'bar' })).rejects.toThrow('createOne is not implemented'));
+
   it('should throw a NotImplementedException when calling deleteMany', () =>
     expect(instance.deleteMany({ foo: { eq: 'bar' } })).rejects.toThrow('deleteMany is not implemented'));
+
   it('should throw a NotImplementedException when calling deleteOne', () =>
     expect(instance.deleteOne(1)).rejects.toThrow('deleteOne is not implemented'));
+
   it('should throw a NotImplementedException when calling findById', () =>
     expect(instance.findById(1)).rejects.toThrow('findById is not implemented'));
+
   it('should throw a NotImplementedException when calling findRelation', () =>
     expect(instance.findRelation(TestType, 'test', new TestType())).rejects.toThrow('findRelation is not implemented'));
+
   it('should throw a NotImplementedException when calling getById', () =>
     expect(instance.getById(1)).rejects.toThrow('getById is not implemented'));
+
   it('should throw a NotImplementedException when calling query', () =>
     expect(instance.query({})).rejects.toThrow('query is not implemented'));
 
@@ -36,22 +45,32 @@ describe('NoOpQueryService', () => {
 
   it('should throw a NotImplementedException when calling count', () =>
     expect(instance.count({})).rejects.toThrow('count is not implemented'));
+
   it('should throw a NotImplementedException when calling queryRelations', () =>
     expect(instance.queryRelations(TestType, 'test', new TestType(), {})).rejects.toThrow(
       'queryRelations is not implemented',
     ));
+
   it('should throw a NotImplementedException when calling countRelations', () =>
     expect(instance.countRelations(TestType, 'test', new TestType(), {})).rejects.toThrow(
       'countRelations is not implemented',
     ));
+
   it('should throw a NotImplementedException when calling removeRelation', () =>
     expect(instance.removeRelation('test', 1, 2)).rejects.toThrow('removeRelation is not implemented'));
+
   it('should throw a NotImplementedException when calling removeRelations', () =>
     expect(instance.removeRelations('test', 1, [1, 2, 3])).rejects.toThrow('removeRelations is not implemented'));
+
   it('should throw a NotImplementedException when calling setRelation', () =>
     expect(instance.setRelation('test', 1, 1)).rejects.toThrow('setRelation is not implemented'));
+
+  it('should throw a NotImplementedException when calling setRelations', () =>
+    expect(instance.setRelations('test', 1, [1])).rejects.toThrow('setRelations is not implemented'));
+
   it('should throw a NotImplementedException when calling updateMany', () =>
     expect(instance.updateMany({ foo: 'bar' }, {})).rejects.toThrow('updateMany is not implemented'));
+
   it('should throw a NotImplementedException when calling updateOne', () =>
     expect(instance.updateOne(1, { foo: 'bar' })).rejects.toThrow('updateOne is not implemented'));
 

--- a/packages/core/__tests__/services/proxy-query.service.spec.ts
+++ b/packages/core/__tests__/services/proxy-query.service.spec.ts
@@ -169,6 +169,14 @@ describe('ProxyQueryService', () => {
     when(mockQueryService.setRelation(relationName, id, relationId, undefined)).thenResolve(result);
     return expect(queryService.setRelation(relationName, id, relationId)).resolves.toBe(result);
   });
+  it('should proxy to the underlying service when calling setRelations', () => {
+    const relationName = 'test';
+    const id = 1;
+    const relationIds = [2];
+    const result = { foo: 'bar' };
+    when(mockQueryService.setRelations(relationName, id, relationIds, undefined)).thenResolve(result);
+    return expect(queryService.setRelations(relationName, id, relationIds)).resolves.toBe(result);
+  });
   it('should proxy to the underlying service when calling updateMany', () => {
     const update = { foo: 'bar' };
     const filter = {};

--- a/packages/core/__tests__/services/relation-query.service.spec.ts
+++ b/packages/core/__tests__/services/relation-query.service.spec.ts
@@ -261,4 +261,14 @@ describe('RelationQueryService', () => {
       return expect(queryService.setRelation(relationName, id, relationId)).resolves.toBe(result);
     });
   });
+  describe('#setRelations', () => {
+    it('should proxy to the underlying service when calling setRelations', () => {
+      const relationName = 'test';
+      const id = 1;
+      const relationIds = [2];
+      const result = { foo: 'bar' };
+      when(mockQueryService.setRelations(relationName, id, relationIds, undefined)).thenResolve(result);
+      return expect(queryService.setRelations(relationName, id, relationIds)).resolves.toBe(result);
+    });
+  });
 });

--- a/packages/core/src/services/assembler-query.service.ts
+++ b/packages/core/src/services/assembler-query.service.ts
@@ -227,6 +227,17 @@ export class AssemblerQueryService<DTO, Entity, C = DeepPartial<DTO>, CE = DeepP
     );
   }
 
+  setRelations<Relation>(
+    relationName: string,
+    id: string | number,
+    relationIds: (string | number)[],
+    opts?: ModifyRelationOptions<DTO, Relation>,
+  ): Promise<DTO> {
+    return this.assembler.convertAsyncToDTO(
+      this.queryService.setRelations(relationName, id, relationIds, this.convertModifyRelationsOptions(opts)),
+    );
+  }
+
   setRelation<Relation>(
     relationName: string,
     id: string | number,

--- a/packages/core/src/services/noop-query.service.ts
+++ b/packages/core/src/services/noop-query.service.ts
@@ -160,6 +160,15 @@ export class NoOpQueryService<DTO, C = DeepPartial<DTO>, U = DeepPartial<DTO>> i
     return Promise.reject(new NotImplementedException('removeRelations is not implemented'));
   }
 
+  setRelations<Relation>(
+    relationName: string,
+    id: string | number,
+    relationId: (string | number)[],
+    opts?: ModifyRelationOptions<DTO, Relation>,
+  ): Promise<DTO> {
+    return Promise.reject(new NotImplementedException('setRelations is not implemented'));
+  }
+
   setRelation<Relation>(
     relationName: string,
     id: string | number,

--- a/packages/core/src/services/proxy-query.service.ts
+++ b/packages/core/src/services/proxy-query.service.ts
@@ -45,6 +45,15 @@ export class ProxyQueryService<DTO, C = DeepPartial<DTO>, U = DeepPartial<DTO>> 
     return this.proxied.removeRelations(relationName, id, relationIds, opts);
   }
 
+  setRelations<Relation>(
+    relationName: string,
+    id: string | number,
+    relationIds: (string | number)[],
+    opts?: ModifyRelationOptions<DTO, Relation>,
+  ): Promise<DTO> {
+    return this.proxied.setRelations(relationName, id, relationIds, opts);
+  }
+
   setRelation<Relation>(
     relationName: string,
     id: string | number,

--- a/packages/core/src/services/query.service.ts
+++ b/packages/core/src/services/query.service.ts
@@ -157,6 +157,22 @@ export interface QueryService<DTO, C = DeepPartial<DTO>, U = DeepPartial<DTO>> {
   ): Promise<DTO>;
 
   /**
+   * Set the relations on the dto.
+   *
+   * @param relationName - The name of the relation to query for.
+   * @param id - The id of the dto to set the relation on.
+   * @param relationIds - The ids of the relation to set on the dto. If the array is empty the relations will be
+   * removed.
+   * @param opts - Additional options.
+   */
+  setRelations<Relation>(
+    relationName: string,
+    id: string | number,
+    relationIds: (string | number)[],
+    opts?: ModifyRelationOptions<DTO, Relation>,
+  ): Promise<DTO>;
+
+  /**
    * Set the relation on the dto.
    *
    * @param relationName - The name of the relation to query for.

--- a/packages/query-graphql/__tests__/resolvers/relations/__fixtures__/update/update-relation-many-custom-name.resolver.graphql
+++ b/packages/query-graphql/__tests__/resolvers/relations/__fixtures__/update/update-relation-many-custom-name.resolver.graphql
@@ -9,6 +9,7 @@ type Query {
 
 type Mutation {
   addTestsToTestResolverDTO(input: RelationsInput!): TestResolverDTO!
+  setTestsOnTestResolverDTO(input: RelationsInput!): TestResolverDTO!
 }
 
 input RelationsInput {

--- a/packages/query-graphql/__tests__/resolvers/relations/__fixtures__/update/update-relation-many.resolver.graphql
+++ b/packages/query-graphql/__tests__/resolvers/relations/__fixtures__/update/update-relation-many.resolver.graphql
@@ -9,6 +9,7 @@ type Query {
 
 type Mutation {
   addRelationsToTestResolverDTO(input: RelationsInput!): TestResolverDTO!
+  setRelationsOnTestResolverDTO(input: RelationsInput!): TestResolverDTO!
 }
 
 input RelationsInput {

--- a/packages/query-graphql/__tests__/resolvers/relations/update-relation.resolver.spec.ts
+++ b/packages/query-graphql/__tests__/resolvers/relations/update-relation.resolver.spec.ts
@@ -102,40 +102,99 @@ describe('UpdateRelationsResolver', () => {
         many: { relations: { DTO: TestRelationDTO, disableUpdate: true } },
       }));
 
-    it('should call the service findRelation with the provided dto and correct relation name', async () => {
-      const { resolver, mockService } = await createResolverFromNest(TestResolver);
-      const input: RelationsInputType = {
-        id: 'id-1',
-        relationIds: ['relation-id-1', 'relation-id-2'],
-      };
-      const output: TestResolverDTO = {
-        id: 'record-id',
-        stringField: 'foo',
-      };
-      when(mockService.addRelations('relations', input.id, deepEqual(input.relationIds), undefined)).thenResolve(
-        output,
-      );
-      // @ts-ignore
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      const result = await resolver.addRelationsToTestResolverDTO({ input });
-      return expect(result).toEqual(output);
+    describe('add relations', () => {
+      it('should call the service addRelations with the dto id and relationIds', async () => {
+        const { resolver, mockService } = await createResolverFromNest(TestResolver);
+        const input: RelationsInputType = {
+          id: 'id-1',
+          relationIds: ['relation-id-1', 'relation-id-2'],
+        };
+        const output: TestResolverDTO = {
+          id: 'record-id',
+          stringField: 'foo',
+        };
+        when(mockService.addRelations('relations', input.id, deepEqual(input.relationIds), undefined)).thenResolve(
+          output,
+        );
+        // @ts-ignore
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        const result = await resolver.addRelationsToTestResolverDTO({ input });
+        return expect(result).toEqual(output);
+      });
+
+      it('should call the service addRelations with the custom dto name dto id and relationIds', async () => {
+        const { resolver, mockService } = await createResolverFromNest(TestResolver);
+        const input: RelationsInputType = {
+          id: 'id-1',
+          relationIds: ['relation-id-1', 'relation-id-2'],
+        };
+        const output: TestResolverDTO = {
+          id: 'record-id',
+          stringField: 'foo',
+        };
+        when(mockService.addRelations('others', input.id, deepEqual(input.relationIds), undefined)).thenResolve(output);
+        // @ts-ignore
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        const result = await resolver.addCustomsToTestResolverDTO({ input });
+        return expect(result).toEqual(output);
+      });
     });
 
-    it('should call the service findRelation with the provided dto and custom relation name', async () => {
-      const { resolver, mockService } = await createResolverFromNest(TestResolver);
-      const input: RelationsInputType = {
-        id: 'id-1',
-        relationIds: ['relation-id-1', 'relation-id-2'],
-      };
-      const output: TestResolverDTO = {
-        id: 'record-id',
-        stringField: 'foo',
-      };
-      when(mockService.addRelations('others', input.id, deepEqual(input.relationIds), undefined)).thenResolve(output);
-      // @ts-ignore
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      const result = await resolver.addCustomsToTestResolverDTO({ input });
-      return expect(result).toEqual(output);
+    describe('set relations', () => {
+      it('should call the service setRelations with the dto id and relationIds', async () => {
+        const { resolver, mockService } = await createResolverFromNest(TestResolver);
+        const input: RelationsInputType = {
+          id: 'id-1',
+          relationIds: ['relation-id-1', 'relation-id-2'],
+        };
+        const output: TestResolverDTO = {
+          id: 'record-id',
+          stringField: 'foo',
+        };
+        when(mockService.setRelations('relations', input.id, deepEqual(input.relationIds), undefined)).thenResolve(
+          output,
+        );
+        // @ts-ignore
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        const result = await resolver.setRelationsOnTestResolverDTO({ input });
+        return expect(result).toEqual(output);
+      });
+
+      it('should call the service setRelations with the dto id and an empty relationIds', async () => {
+        const { resolver, mockService } = await createResolverFromNest(TestResolver);
+        const input: RelationsInputType = {
+          id: 'id-1',
+          relationIds: [],
+        };
+        const output: TestResolverDTO = {
+          id: 'record-id',
+          stringField: 'foo',
+        };
+        when(mockService.setRelations('relations', input.id, deepEqual(input.relationIds), undefined)).thenResolve(
+          output,
+        );
+        // @ts-ignore
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        const result = await resolver.setRelationsOnTestResolverDTO({ input });
+        return expect(result).toEqual(output);
+      });
+
+      it('should call the service setRelations with the custom dto name dto id and relationIds', async () => {
+        const { resolver, mockService } = await createResolverFromNest(TestResolver);
+        const input: RelationsInputType = {
+          id: 'id-1',
+          relationIds: ['relation-id-1', 'relation-id-2'],
+        };
+        const output: TestResolverDTO = {
+          id: 'record-id',
+          stringField: 'foo',
+        };
+        when(mockService.setRelations('others', input.id, deepEqual(input.relationIds), undefined)).thenResolve(output);
+        // @ts-ignore
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        const result = await resolver.setCustomsOnTestResolverDTO({ input });
+        return expect(result).toEqual(output);
+      });
     });
   });
 });

--- a/packages/query-graphql/__tests__/types/relations-input.type.spec.ts
+++ b/packages/query-graphql/__tests__/types/relations-input.type.spec.ts
@@ -61,21 +61,11 @@ describe('RelationsInputType', (): void => {
       ]);
     });
 
-    it('should validate that relationsIds is not empty', () => {
+    it('should allow an empty relationIds array', () => {
       const input: RelationsInputType = { id: 1, relationIds: [] };
       const it = plainToClass(RelationsInput, input);
       const errors = validateSync(it);
-      expect(errors).toEqual([
-        {
-          children: [],
-          constraints: {
-            arrayNotEmpty: 'relationIds should not be empty',
-          },
-          property: 'relationIds',
-          target: input,
-          value: input.relationIds,
-        },
-      ]);
+      expect(errors).toEqual([]);
     });
 
     it('should validate that relationsIds is unique', () => {

--- a/packages/query-graphql/src/resolvers/relations/update-relations.resolver.ts
+++ b/packages/query-graphql/src/resolvers/relations/update-relations.resolver.ts
@@ -78,6 +78,21 @@ const UpdateManyRelationMixin = <DTO, Relation>(DTOClass: Class<DTO>, relation: 
       const { input } = await transformAndValidate(AddArgs, addArgs);
       return this.service.addRelations(relationName, input.id, input.relationIds, modifyRelationsFilter);
     }
+
+    @ResolverMutation(() => DTOClass, {}, commonResolverOpts, {
+      interceptors: [AuthorizerInterceptor(DTOClass)],
+    })
+    async [`set${pluralBaseName}On${dtoNames.baseName}`](
+      @Args() addArgs: AddArgs,
+      @ModifyRelationAuthorizerFilter(pluralBaseNameLower, {
+        operationGroup: OperationGroup.UPDATE,
+        many: true,
+      })
+      modifyRelationsFilter?: ModifyRelationOptions<DTO, Relation>,
+    ): Promise<DTO> {
+      const { input } = await transformAndValidate(AddArgs, addArgs);
+      return this.service.setRelations(relationName, input.id, input.relationIds, modifyRelationsFilter);
+    }
   }
   return UpdateManyMixin;
 };

--- a/packages/query-graphql/src/types/relations-input.type.ts
+++ b/packages/query-graphql/src/types/relations-input.type.ts
@@ -1,6 +1,6 @@
 import { Class } from '@nestjs-query/core';
 import { Field, ID, InputType } from '@nestjs/graphql';
-import { IsNotEmpty, ArrayNotEmpty, ArrayUnique } from 'class-validator';
+import { IsNotEmpty, ArrayUnique } from 'class-validator';
 
 export interface RelationsInputType {
   id: string | number;
@@ -21,7 +21,6 @@ export function RelationsInputType(): Class<RelationsInputType> {
     id!: string | number;
 
     @Field(() => [ID], { description: 'The ids of the relations.' })
-    @ArrayNotEmpty()
     @ArrayUnique()
     @IsNotEmpty({ each: true })
     relationIds!: (string | number)[];

--- a/packages/query-mongoose/__tests__/services/mongoose-query.service.spec.ts
+++ b/packages/query-mongoose/__tests__/services/mongoose-query.service.spec.ts
@@ -1218,6 +1218,21 @@ describe('MongooseQueryService', () => {
       expect(relations).toHaveLength(6);
     });
 
+    it('should not modify relations if relationIds is empty', async () => {
+      const entity = TEST_ENTITIES[0];
+      const queryService = moduleRef.get(TestEntityService);
+      const queryResult = await queryService.addRelations('testReferences', entity._id, []);
+      expect(queryResult).toEqual(
+        expect.objectContaining({
+          _id: entity._id,
+          testReferences: expect.arrayContaining(TEST_REFERENCES.slice(0, 3).map((r) => r._id)),
+        }),
+      );
+
+      const relations = await queryService.queryRelations(TestReference, 'testReferences', entity, {});
+      expect(relations).toHaveLength(3);
+    });
+
     describe('with virtual reference', () => {
       it('should return a rejected promise', async () => {
         const entity = TEST_ENTITIES[0];
@@ -1390,6 +1405,21 @@ describe('MongooseQueryService', () => {
 
       const relations = await queryService.queryRelations(TestReference, 'testReferences', entity, {});
       expect(relations).toHaveLength(0);
+    });
+
+    it('should not modify relations if relationIds is empty', async () => {
+      const entity = TEST_ENTITIES[0];
+      const queryService = moduleRef.get(TestEntityService);
+      const queryResult = await queryService.removeRelations('testReferences', entity._id, []);
+      expect(queryResult.toObject()).toEqual(
+        expect.objectContaining({
+          _id: entity._id,
+          testReferences: expect.arrayContaining(TEST_REFERENCES.slice(0, 3).map((r) => r._id)),
+        }),
+      );
+
+      const relations = await queryService.queryRelations(TestReference, 'testReferences', entity, {});
+      expect(relations).toHaveLength(3);
     });
 
     describe('with virtual reference', () => {

--- a/packages/query-mongoose/src/services/reference-query.service.ts
+++ b/packages/query-mongoose/src/services/reference-query.service.ts
@@ -208,6 +208,23 @@ export abstract class ReferenceQueryService<Entity extends Document> {
     return this.getById(id);
   }
 
+  async setRelations<Relation extends Document>(
+    relationName: string,
+    id: string,
+    relationIds: (string | number)[],
+    opts?: ModifyRelationOptions<Entity, Relation>,
+  ): Promise<Entity> {
+    this.checkForReference('AddRelations', relationName, false);
+    const entity = await this.getById(id, opts);
+    const refCount = await this.getRefCount(relationName, relationIds, opts?.relationFilter);
+    if (relationIds.length !== refCount) {
+      throw new Error(`Unable to find all ${relationName} to set on ${this.Model.modelName}`);
+    }
+    await entity.updateOne({ [relationName]: relationIds } as UpdateQuery<Entity>).exec();
+    // reload the document
+    return this.getById(id);
+  }
+
   async setRelation<Relation extends Document>(
     relationName: string,
     id: string | number,

--- a/packages/query-sequelize/__tests__/services/sequelize-query.service.spec.ts
+++ b/packages/query-sequelize/__tests__/services/sequelize-query.service.spec.ts
@@ -834,6 +834,16 @@ describe('SequelizeQueryService', (): void => {
       expect(relations).toHaveLength(6);
     });
 
+    it('should not modify relations if the relationIds is empty', async () => {
+      const entity = PLAIN_TEST_ENTITIES[0] as TestEntity;
+      const queryService = moduleRef.get(TestEntityService);
+      const queryResult = await queryService.addRelations('testRelations', entity.testEntityPk, []);
+      expect(queryResult).toEqual(expect.objectContaining(entity));
+
+      const relations = await queryService.queryRelations(TestRelation, 'testRelations', entity, {});
+      expect(relations).toHaveLength(3);
+    });
+
     describe('with modify options', () => {
       it('should throw an error if the entity is not found with the id and provided filter', async () => {
         const entity = PLAIN_TEST_ENTITIES[0];
@@ -978,6 +988,16 @@ describe('SequelizeQueryService', (): void => {
 
       const relations = await queryService.queryRelations(TestRelation, 'testRelations', entity, {});
       expect(relations).toHaveLength(0);
+    });
+
+    it('should not modify relations if relationIds is empty', async () => {
+      const entity = PLAIN_TEST_ENTITIES[0] as TestEntity;
+      const queryService = moduleRef.get(TestEntityService);
+      const queryResult = await queryService.removeRelations('testRelations', entity.testEntityPk, []);
+      expect(queryResult).toEqual(expect.objectContaining(entity));
+
+      const relations = await queryService.queryRelations(TestRelation, 'testRelations', entity, {});
+      expect(relations).toHaveLength(3);
     });
 
     describe('with modify options', () => {

--- a/packages/query-sequelize/src/services/relation-query.service.ts
+++ b/packages/query-sequelize/src/services/relation-query.service.ts
@@ -230,6 +230,32 @@ export abstract class RelationQueryService<Entity extends Model<Entity, Partial<
   }
 
   /**
+   * Set the relations on the entity.
+   *
+   * @param id - The id of the entity to set the relation on.
+   * @param relationName - The name of the relation to query for.
+   * @param relationIds - The ids of the relation to set on the entity. If the relationIds is empty all relations
+   * will be removed.
+   * @param opts - Additional options
+   */
+  async setRelations<Relation>(
+    relationName: string,
+    id: string | number,
+    relationIds: string[] | number[],
+    opts?: ModifyRelationOptions<Entity, Relation>,
+  ): Promise<Entity> {
+    const entity = await this.getById(id, opts);
+    if (relationIds.length) {
+      const relations = await this.getRelations(relationName, relationIds, opts?.relationFilter);
+      if (relations.length !== relationIds.length) {
+        throw new Error(`Unable to find all ${relationName} to set on ${this.model.name}`);
+      }
+    }
+    await entity.$set(relationName as keyof Entity, relationIds);
+    return entity;
+  }
+
+  /**
    * Set the relation on the entity.
    *
    * @param id - The id of the entity to set the relation on.

--- a/packages/query-typegoose/__tests__/services/typegoose-query.service.spec.ts
+++ b/packages/query-typegoose/__tests__/services/typegoose-query.service.spec.ts
@@ -1222,6 +1222,21 @@ describe('TypegooseQueryService', () => {
       expect(relations).toHaveLength(6);
     });
 
+    it('should not modify relations if relationIds is empty', async () => {
+      const entity = TEST_ENTITIES[0];
+      const queryService = moduleRef.get(TestEntityService);
+      const queryResult = await queryService.addRelations('testReferences', entity._id.toHexString(), []);
+      expect(queryResult).toEqual(
+        expect.objectContaining({
+          _id: entity._id,
+          testReferences: expect.arrayContaining(TEST_REFERENCES.slice(0, 3).map((r) => r._id)),
+        }),
+      );
+
+      const relations = await queryService.queryRelations(TestReference, 'testReferences', entity, {});
+      expect(relations).toHaveLength(3);
+    });
+
     describe('with virtual reference', () => {
       it('should return a rejected promise', async () => {
         const entity = TEST_ENTITIES[0];
@@ -1459,6 +1474,21 @@ describe('TypegooseQueryService', () => {
 
       const relations = await queryService.queryRelations(TestReference, 'testReferences', entity, {});
       expect(relations).toHaveLength(0);
+    });
+
+    it('should not modify relations if relationIds is empty', async () => {
+      const entity = TEST_ENTITIES[0];
+      const queryService = moduleRef.get(TestEntityService);
+      const queryResult = await queryService.removeRelations('testReferences', entity._id.toHexString(), []);
+      expect(queryResult.toObject()).toEqual(
+        expect.objectContaining({
+          _id: entity._id,
+          testReferences: expect.arrayContaining(TEST_REFERENCES.slice(0, 3).map((r) => r._id)),
+        }),
+      );
+
+      const relations = await queryService.queryRelations(TestReference, 'testReferences', entity, {});
+      expect(relations).toHaveLength(3);
     });
 
     describe('with virtual reference', () => {

--- a/packages/query-typegoose/__tests__/services/typegoose-query.service.spec.ts
+++ b/packages/query-typegoose/__tests__/services/typegoose-query.service.spec.ts
@@ -1269,6 +1269,75 @@ describe('TypegooseQueryService', () => {
     });
   });
 
+  describe('#setRelations', () => {
+    it('set all relations on the entity', async () => {
+      const entity = TEST_ENTITIES[0];
+      const queryService = moduleRef.get(TestEntityService);
+      const relationIds = TEST_REFERENCES.slice(3, 6).map((r) => r._id);
+      const queryResult = await queryService.setRelations(
+        'testReferences',
+        entity._id.toHexString(),
+        relationIds.map((id) => id.toHexString()),
+      );
+      expect(queryResult).toEqual(
+        expect.objectContaining({
+          _id: entity._id,
+          testReferences: expect.arrayContaining(relationIds),
+        }),
+      );
+
+      const relations = await queryService.queryRelations(TestReference, 'testReferences', entity, {});
+      expect(relations.map((r) => r._id)).toEqual(relationIds);
+    });
+
+    it('should remove all relations if the relationIds is empty', async () => {
+      const entity = TEST_ENTITIES[0];
+      const queryService = moduleRef.get(TestEntityService);
+      const queryResult = await queryService.setRelations('testReferences', entity._id.toHexString(), []);
+      expect(queryResult).toEqual(
+        expect.objectContaining({
+          _id: entity._id,
+          testReferences: expect.arrayContaining([]),
+        }),
+      );
+
+      const relations = await queryService.queryRelations(TestReference, 'testReferences', entity, {});
+      expect(relations.map((r) => r._id)).toEqual([]);
+    });
+
+    describe('with modify options', () => {
+      it('should throw an error if the entity is not found with the id and provided filter', async () => {
+        const entity = TEST_ENTITIES[0];
+        const queryService = moduleRef.get(TestEntityService);
+        return expect(
+          queryService.setRelations(
+            'testReferences',
+            entity._id.toHexString(),
+            TEST_REFERENCES.slice(3, 6).map((r) => r._id.toHexString()),
+            {
+              filter: { stringType: { eq: TEST_ENTITIES[1].stringType } },
+            },
+          ),
+        ).rejects.toThrow(`Unable to find TestEntity with id: ${String(entity._id)}`);
+      });
+
+      it('should throw an error if the relations are not found with the relationIds and provided filter', async () => {
+        const entity = TEST_ENTITIES[0];
+        const queryService = moduleRef.get(TestEntityService);
+        return expect(
+          queryService.setRelations<TestReference>(
+            'testReferences',
+            entity._id.toHexString(),
+            TEST_REFERENCES.slice(3, 6).map((r) => r._id.toHexString()),
+            {
+              relationFilter: { referenceName: { like: '%-one' } },
+            },
+          ),
+        ).rejects.toThrow('Unable to find all testReferences to set on TestEntity');
+      });
+    });
+  });
+
   describe('#setRelation', () => {
     it('call select and return the result', async () => {
       const entity = TEST_REFERENCES[0];

--- a/packages/query-typegoose/src/services/reference-query.service.ts
+++ b/packages/query-typegoose/src/services/reference-query.service.ts
@@ -221,6 +221,25 @@ export abstract class ReferenceQueryService<Entity extends Base> {
     return entity;
   }
 
+  async setRelations<Relation>(
+    relationName: string,
+    id: string,
+    relationIds: (string | number)[],
+    opts?: ModifyRelationOptions<Entity, Relation>,
+  ): Promise<DocumentType<Entity>> {
+    this.checkForReference('AddRelations', relationName, false);
+    const refCount = await this.getRefCount(relationName, relationIds, opts?.relationFilter);
+    if (relationIds.length !== refCount) {
+      throw new Error(`Unable to find all ${relationName} to set on ${this.Model.modelName}`);
+    }
+    const entity = await this.findAndUpdate(
+      id,
+      opts?.filter as Filter<Entity>,
+      { [relationName]: relationIds } as UpdateQuery<DocumentType<Entity>>,
+    );
+    return entity;
+  }
+
   async setRelation<Relation>(
     relationName: string,
     id: string | number,

--- a/packages/query-typeorm/__tests__/services/typeorm-query.service.spec.ts
+++ b/packages/query-typeorm/__tests__/services/typeorm-query.service.spec.ts
@@ -1138,6 +1138,16 @@ describe('TypeOrmQueryService', (): void => {
       expect(relations).toHaveLength(6);
     });
 
+    it('should not modify if the relationIds is empty', async () => {
+      const entity = TEST_ENTITIES[0];
+      const queryService = moduleRef.get(TestEntityService);
+      const queryResult = await queryService.addRelations('testRelations', entity.testEntityPk, []);
+      expect(queryResult).toEqual(entity);
+
+      const relations = await queryService.queryRelations(TestRelation, 'testRelations', entity, {});
+      expect(relations).toHaveLength(3);
+    });
+
     describe('with modify options', () => {
       it('should throw an error if the entity is not found with the id and provided filter', async () => {
         const entity = TEST_ENTITIES[0];
@@ -1282,6 +1292,16 @@ describe('TypeOrmQueryService', (): void => {
 
       const relations = await queryService.queryRelations(TestRelation, 'testRelations', entity, {});
       expect(relations).toHaveLength(0);
+    });
+
+    it('should not remove any relations if relationIds is empty', async () => {
+      const entity = TEST_ENTITIES[0];
+      const queryService = moduleRef.get(TestEntityService);
+      const queryResult = await queryService.removeRelations('testRelations', entity.testEntityPk, []);
+      expect(queryResult).toEqual(entity);
+
+      const relations = await queryService.queryRelations(TestRelation, 'testRelations', entity, {});
+      expect(relations).toHaveLength(3);
     });
 
     describe('with modify options', () => {


### PR DESCRIPTION
This PR adds the ability to set a relation, replacing the need to call the add and remove mutations through graphql.

The changes include

* Defining a new `setRelations` method on the `QueryService` interface
* Implementing `setRelations` in `Typeorm`, `sequelize`, `mongoose`, and `typegoose`
* Exposing the `set{PluralRelationName}On{DTOName}` mutation 
* Remove the restriction on empty `relationIds` in the `RelationsInputType`
* Add new tests to the persistence packages for empty relationIds on `set`, `add`, and `remove` relation methods
* Add `e2e` tests for each `persistence` pacakge
* Update docs for the new `setRelations` method. 