### PR TITLE
Export ProxyQueryService from core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export {
   RelationQueryService,
   NoOpQueryService,
   QueryServiceRelation,
+  ProxyQueryService,
 } from './services';
 export {
   transformFilter,

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -2,3 +2,4 @@ export { QueryService } from './query.service';
 export { AssemblerQueryService } from './assembler-query.service';
 export { RelationQueryService, QueryServiceRelation } from './relation-query.service';
 export { NoOpQueryService } from './noop-query.service';
+export { ProxyQueryService } from './proxy-query.service';


### PR DESCRIPTION
ProxyQueryService is referenced in the docs in a few [examples](https://doug-martin.github.io/nestjs-query/docs/concepts/services#proxyqueryservice) but hasn't been exported.