### PR TITLE
[typegoose] default assembler for creation is unusable

### DIFF
--- a/packages/query-typegoose/src/services/typegoose-query-service.ts
+++ b/packages/query-typegoose/src/services/typegoose-query-service.ts
@@ -237,7 +237,11 @@ export class TypegooseQueryService<Entity extends Base>
   }
 
   private ensureIdIsNotPresent(e: DeepPartial<Entity>): void {
-    if (Object.keys(e).find((f) => f === 'id' || f === '_id')) {
+    if (
+      Object.keys(e)
+        .filter((v) => typeof e[v] !== `undefined`)
+        .find((f) => f === 'id' || f === '_id')
+    ) {
       throw new Error('Id cannot be specified when updating or creating');
     }
   }


### PR DESCRIPTION
### Problem

When trying the basic functionalities with typegoose, every GraphQL call to createOne/createMany fails with the error: `Id cannot be specified when updating or creating`.

### Debug

The first place I found was [this line](https://github.com/doug-martin/nestjs-query/blob/fb6dc5455a412f16acc10c436881bf6fd139b34e/packages/query-typegoose/src/services/typegoose-query-service.ts#L239), where the error is thrown.

Then I found that the error-throwing function was called with argument `{ id: undefined }`. This weird object comes from [here](https://github.com/doug-martin/nestjs-query/blob/fb6dc5455a412f16acc10c436881bf6fd139b34e/packages/core/src/assemblers/class-transformer.assembler.ts#L53).

Hence I believe that the default behaviour is broken somehow.

### Solution

There are 2 places where it can be fixed(see the 2 links above). As one of them is related to an external dependency `class-transformer`, it is easier to fix it from the other side.