### PR TITLE
Fix: query service to extend in docs

### DIFF
--- a/documentation/docs/persistence/mongoose/custom-service.md
+++ b/documentation/docs/persistence/mongoose/custom-service.md
@@ -2,7 +2,7 @@
 title: Custom Service
 ---
 
-To create a custom query service to add your own methods to you can extend the `SequelizeQueryService`.
+To create a custom query service to add your own methods to you can extend the `MongooseQueryService`.
 
 ```ts title="todo-item.service.ts"
 import { QueryService } from '@nestjs-query/core';


### PR DESCRIPTION
docs: Service to extend in Mongoose is `MongooseQueryService`