### PR TITLE
fix(query-graphql): pass original query in keyset pager strategy

### DIFF
--- a/packages/query-graphql/__tests__/types/connection/cursor-connection.type.spec.ts
+++ b/packages/query-graphql/__tests__/types/connection/cursor-connection.type.spec.ts
@@ -102,6 +102,15 @@ describe('CursorConnectionType', (): void => {
         });
       });
 
+      it('should pass additional query params to queryMany', async () => {
+        const queryMany = jest.fn();
+        const dtos = [createTestDTO(1), createTestDTO(2)];
+        queryMany.mockResolvedValueOnce([...dtos]);
+        await TestConnection.createFromPromise(queryMany, { search: 'searchString', paging: createPage({ first: 2 }) });
+        expect(queryMany).toHaveBeenCalledTimes(1);
+        expect(queryMany).toHaveBeenCalledWith({ search: 'searchString', paging: { limit: 3, offset: 0 } });
+      });
+
       it('should create a connections response with an empty paging', async () => {
         const queryMany = jest.fn();
         const response = await TestConnection.createFromPromise(queryMany, { paging: {} });

--- a/packages/query-graphql/__tests__/types/connection/offset-connection.type.spec.ts
+++ b/packages/query-graphql/__tests__/types/connection/offset-connection.type.spec.ts
@@ -101,6 +101,18 @@ describe('OffsetConnectionType', (): void => {
         });
       });
 
+      it('should pass additional query params to queryMany', async () => {
+        const queryMany = jest.fn();
+        const dtos = [createTestDTO(1), createTestDTO(2)];
+        queryMany.mockResolvedValueOnce([...dtos]);
+        await TestConnection.createFromPromise(queryMany, {
+          search: 'searchString',
+          paging: createPage({ limit: 2 }),
+        });
+        expect(queryMany).toHaveBeenCalledTimes(1);
+        expect(queryMany).toHaveBeenCalledWith({ search: 'searchString', paging: { limit: 3, offset: 0 } });
+      });
+
       it('should create a connections response with an empty paging', async () => {
         const queryMany = jest.fn();
         const response = await TestConnection.createFromPromise(queryMany, { paging: {} });

--- a/packages/query-graphql/src/types/connection/cursor/pager/strategies/keyset.pager-strategy.ts
+++ b/packages/query-graphql/src/types/connection/cursor/pager/strategies/keyset.pager-strategy.ts
@@ -48,7 +48,7 @@ export class KeysetPagerStrategy<DTO> implements PagerStrategy<DTO> {
     // Add 1 to the limit so we will fetch an additional node with the current node
     const sorting = this.getSortFields(query, opts);
     const filter = mergeFilter(query.filter ?? {}, this.createFieldsFilter(sorting, payload));
-    return { filter, paging, sorting };
+    return { ...query, filter, paging, sorting };
   }
 
   checkForExtraNode(nodes: DTO[], opts: KeySetPagingOpts<DTO>): DTO[] {

--- a/packages/query-graphql/src/types/connection/interfaces.ts
+++ b/packages/query-graphql/src/types/connection/interfaces.ts
@@ -81,7 +81,7 @@ export interface StaticConnectionType<DTO, S extends PagingStrategies>
   resolveType: ReturnTypeFuncValue;
   createFromPromise(
     queryMany: QueryMany<DTO>,
-    query: Query<DTO>,
+    query: Query<DTO> & Record<string, any>,
     count?: Count<DTO>,
   ): Promise<InferConnectionTypeFromStrategy<DTO, S>>;
 }


### PR DESCRIPTION
Hi,

in LimitOffsetPagerStrategy, the original query is spreaded into the returned query:
```
createQuery(query: Query<DTO>, opts: OffsetPagingOpts, includeExtraNode: boolean): Query<DTO> {
    const { isBackward } = opts;
    const paging = { limit: opts.limit, offset: opts.offset };
    if (includeExtraNode) {
      // Add 1 to the limit so we will fetch an additional node
      paging.limit += 1;
      // if paging backwards remove one from the offset to check for a previous page.
      if (isBackward) {
        paging.offset -= 1;
      }
      if (paging.offset < 0) {
        // if the offset is < 0 it means we underflowed and that we cant have an extra page.
        paging.offset = 0;
        paging.limit = opts.limit;
      }
    }
    return { ...query, paging };
  }
```
This PR adds this behaviour to the `KeysetPagerStrategy`.

The motivation is that if you extend the QueryArgs, e.g. 
```
@ArgsType()
  class SearchableQueryArgs
    extends QueryArgsType(DTOClass, opts)
    implements Searchable
  {
    @Field(() => GraphQLString, { nullable: true })
    @IsOptional()
    search?: string;
  }
```
the additional fields are passed to the service.
