### PR TITLE
docs: Update mongoose package readme

### DIFF
--- a/packages/query-mongoose/README.md
+++ b/packages/query-mongoose/README.md
@@ -2,14 +2,14 @@
   <a href="https://doug-martin.github.io/nestjs-query" target="blank"><img src="https://doug-martin.github.io/nestjs-query/img/logo.svg" width="120" alt="Nestjs-query Logo" /></a>
 </p>
 
-[![npm version](https://img.shields.io/npm/v/@nestjs-query/query-typeorm.svg)](https://www.npmjs.org/package/@nestjs-query/query-typeorm)
+[![npm version](https://img.shields.io/npm/v/@nestjs-query/query-mongoose.svg)](https://www.npmjs.org/package/@nestjs-query/query-mongoose)
 [![Test](https://github.com/doug-martin/nestjs-query/workflows/Test/badge.svg?branch=master)](https://github.com/doug-martin/nestjs-query/actions?query=workflow%3ATest+and+branch%3Amaster+)
 [![Coverage Status](https://coveralls.io/repos/github/doug-martin/nestjs-query/badge.svg?branch=master)](https://coveralls.io/github/doug-martin/nestjs-query?branch=master)
-[![Known Vulnerabilities](https://snyk.io/test/github/doug-martin/nestjs-query/badge.svg?targetFile=packages/query-typeorm/package.json)](https://snyk.io/test/github/doug-martin/nestjs-query?targetFile=packages/query-typeorm/package.json)
+[![Known Vulnerabilities](https://snyk.io/test/github/doug-martin/nestjs-query/badge.svg?targetFile=packages/query-mongoose/package.json)](https://snyk.io/test/github/doug-martin/nestjs-query?targetFile=packages/query-mongoose/package.json)
 
-# `@nestjs-query/query-typeorm`
+# `@nestjs-query/query-mongoose`
 
-The `query-typeorm` package that provides an implementation of `@nestjs-query/core` `QueryService`, built on top of of [nestjs](https://nestjs.com/) and [typeorm](https://typeorm.io/). 
+The `query-mongoose` package that provides an implementation of `@nestjs-query/core` `QueryService`, built on top of of [nestjs](https://nestjs.com/) and [mongoose](https://mongoosejs.com/). 
 
 ## Installation
 
@@ -17,6 +17,6 @@ The `query-typeorm` package that provides an implementation of `@nestjs-query/co
 
 ## Getting Started
 
-The get started with the `@nestjs-query/query-typeorm` package checkout the [Getting Started](https://doug-martin.github.io/nestjs-query/docs/persistence/typeorm/getting-started) docs.
+The get started with the `@nestjs-query/query-mongoose` package checkout the [Getting Started](https://doug-martin.github.io/nestjs-query/docs/persistence/mongoose/getting-started) docs.
 
 


### PR DESCRIPTION
remove the references to typeorm in the readme