### PR TITLE
fix: allow discriminators to be used with typegoose

### DIFF
--- a/packages/query-typegoose/src/module.ts
+++ b/packages/query-typegoose/src/module.ts
@@ -1,7 +1,8 @@
 import { DynamicModule } from '@nestjs/common';
-import { TypegooseModule, TypegooseClass, TypegooseClassWithOptions } from 'nestjs-typegoose';
+import { TypegooseModule } from 'nestjs-typegoose';
 import { Class } from '@nestjs-query/core';
 import { createTypegooseQueryServiceProviders } from './providers';
+import { TypegooseClassWithOptions, TypegooseClass } from 'nestjs-typegoose/dist/typegoose-class.interface';
 
 export class NestjsQueryTypegooseModule {
   static forFeature(models: (TypegooseClass | TypegooseClassWithOptions)[], connectionName?: string): DynamicModule {

--- a/packages/query-typegoose/src/module.ts
+++ b/packages/query-typegoose/src/module.ts
@@ -1,10 +1,10 @@
 import { DynamicModule } from '@nestjs/common';
-import { TypegooseModule } from 'nestjs-typegoose';
+import { TypegooseModule, TypegooseClass, TypegooseClassWithOptions } from 'nestjs-typegoose';
 import { Class } from '@nestjs-query/core';
 import { createTypegooseQueryServiceProviders } from './providers';
 
 export class NestjsQueryTypegooseModule {
-  static forFeature(models: Class<unknown>[], connectionName?: string): DynamicModule {
+  static forFeature(models: (TypegooseClass | TypegooseClassWithOptions)[], connectionName?: string): DynamicModule {
     const queryServiceProviders = createTypegooseQueryServiceProviders(models);
     const typegooseModule = TypegooseModule.forFeature(models, connectionName);
     return {


### PR DESCRIPTION
this pr will allow the use of discriminators by `nestjs-typegoose` under the hood of `@nestjs-query/query-typegoose`.

in pure `nestjs-typegoose` we can use the following syntax:
```ts
@Module({
  imports: [
    TypegooseModule.forFeature([
      {
        typegooseClass: Cat,
        discriminators: [
          Tabby,
          {
            typegooseClass: BlackCat,
            discriminatorId: 'Black'
          }
        ]
      }
    ])
  ]
})
export class CatsModule {}
```

this is not currently possible to do with `NestjsQueryTypegooseModule` as it throws a type error. This Pr fixes the type used the the method `NestjsQueryTypegooseModule.forFeature` to allow that syntax to happen

```ts
NestjsQueryTypegooseModule.forFeature([
          {
            typegooseClass: User,
            discriminators: [
              {
                typegooseClass: UserEmail,
                discriminatorId: ProviderType.EMAIL,
              },
              {
                typegooseClass: UserFacebook,
                discriminatorId: ProviderType.FACEBOOK,
              },
            ],
          },
        ]),
```
