### PR TITLE
fix: add relation filter to relation select builder

### DIFF
--- a/packages/query-typeorm/src/query/filter-query.builder.ts
+++ b/packages/query-typeorm/src/query/filter-query.builder.ts
@@ -208,7 +208,7 @@ export class FilterQueryBuilder<Entity> {
    *
    * @returns the query builder for chaining
    */
-  private applyRelationJoins(qb: SelectQueryBuilder<Entity>, filter?: Filter<Entity>): SelectQueryBuilder<Entity> {
+  applyRelationJoins(qb: SelectQueryBuilder<Entity>, filter?: Filter<Entity>): SelectQueryBuilder<Entity> {
     if (!filter) {
       return qb;
     }
@@ -219,11 +219,10 @@ export class FilterQueryBuilder<Entity> {
   /**
    * Checks if a filter references any relations.
    * @param filter
-   * @private
    *
    * @returns true if there are any referenced relations
    */
-  private filterHasRelations(filter?: Filter<Entity>): boolean {
+  filterHasRelations(filter?: Filter<Entity>): boolean {
     if (!filter) {
       return false;
     }

--- a/packages/query-typeorm/src/query/relation-query.builder.ts
+++ b/packages/query-typeorm/src/query/relation-query.builder.ts
@@ -71,7 +71,11 @@ export class RelationQueryBuilder<Entity, Relation> {
   }
 
   select(entity: Entity, query: Query<Relation>): SelectQueryBuilder<Relation> {
+    const hasRelations = this.filterQueryBuilder.filterHasRelations(query.filter);
     let relationBuilder = this.createRelationQueryBuilder(entity);
+    relationBuilder = hasRelations
+      ? this.filterQueryBuilder.applyRelationJoins(relationBuilder, query.filter)
+      : relationBuilder;
     relationBuilder = this.filterQueryBuilder.applyFilter(relationBuilder, query.filter, relationBuilder.alias);
     relationBuilder = this.filterQueryBuilder.applyPaging(relationBuilder, query.paging);
     return this.filterQueryBuilder.applySorting(relationBuilder, query.sorting, relationBuilder.alias);


### PR DESCRIPTION
Given the three following entities

```ts
@Entity()
@CursorConnection('elements', () => ShipmentElement)
export class Shipment extends BaseEntity {
  @OneToMany(() => ShipmentElement, shipmentElement => shipmentElement.shipment, {
    lazy: true,
    cascade: true,
  })
  elements!: ShipmentElement[];
}

@FilterableRelation('equipment', () => Equipment, { nullable: true })
export class ShipmentElement extends BaseEntity {
  @ManyToOne(() => Equipment, (equipment: Equipment) => equipment.shipmentElements, {
    nullable: true,
    lazy: true,
    cascade: true,
    onDelete: 'CASCADE',
  })
  equipment: Equipment | null = null;
}

export class Equipment extends BaseEntity {
  @FilterableField()
  @Column()
  description!: string;
}
```

the following request will fail : 

```
{
  shipment(id: "C920433E-F36B-1410-8107-00554FDCA37B") {
    id
    elements(
      filter: {
        equipment: { description: { like: "%all%" } }
      }
      paging: { first: 10, after: "" }
    ) {
      totalCount
      pageInfo {
        hasNextPage
      }
      edges {
        cursor
        node {
          id
          equipment {
            id
          }
        }
      }
    }
  }
}
```

I noticed that the unioned query does not joint the tables needed to apply the filters