### PR TITLE
fix(query-graphql): Custom authorizers now behave like auth decorators

### DIFF
--- a/documentation/docs/graphql/authorization.mdx
+++ b/documentation/docs/graphql/authorization.mdx
@@ -249,11 +249,12 @@ For example you could define the subtasks with the `auth` option, only allowing 
 When you need more control over authorization you can create a custom `Authorizer`. You may want to use a custom
 `Authorizer` if you need to use additional services to do authorization for a DTO.
 
-The `Authorizer` interface requires two methods to be implemented
+The `CustomAuthorizer` interface ensures two methods:
 
 - `authorize` - Should return a filter that should be used for all queries and mutations for the DTO.
-- `authorizeRelation` - Should return a filter for the relation that will be used when querying the relation or
-  adding/removing relations to/from the DTO.
+- `authorizeRelation` - Optionally modify the filter for the relation that will be used when querying the relation or
+  adding/removing relations to/from the DTO. If undefined is returned, the authorization filter of the relation DTO
+  will be used instead.
 
 In this example we'll create a simple authorizer for `SubTasks`. You can use this as a base to create a more complex
 authorizers that depends on other services.
@@ -266,16 +267,16 @@ import { UserContext } from '../auth/auth.interfaces';
 import { SubTaskDTO } from './dto/sub-task.dto';
 
 @Injectable()
-export class SubTaskAuthorizer implements Authorizer<SubTaskDTO> {
+export class SubTaskAuthorizer implements CustomAuthorizer<SubTaskDTO> {
   authorize(context: UserContext): Promise<Filter<SubTaskDTO>> {
     return Promise.resolve({ ownerId: { eq: context.req.user.id } });
   }
 
-  authorizeRelation(relationName: string, context: UserContext): Promise<Filter<unknown>> {
+  authorizeRelation(relationName: string, context: UserContext): Promise<Filter<unknown> | undefined> {
     if (relationName === 'todoItem') {
       return Promise.resolve({ ownerId: { eq: context.req.user.id } });
     }
-    return Promise.resolve({});
+    return Promise.resolve(undefined);
   }
 }
 ```
@@ -396,6 +397,11 @@ export class TodoItemResolver extends CRUDResolver(TodoItemDTO) {
 
 :::important
 If you are extending the `CRUDResolver` directly be sure to [register your DTOs with the `NestjsQueryGraphQLModule`](./resolvers.mdx#crudresolver)
+:::
+
+:::important
+When using `@InjectAuthorizer`, the injected Authorizer is not the CustomAuthorizer, but the DefaultCRUDAuthorizer that internally uses the CustomAuthorizer.
+If you want to use the CustomAuthorizer directly, inject it with `@InjectCustomAuthorizer` instead.
 :::
 
 ## Authorize depending on operation

--- a/documentation/docs/graphql/authorization.mdx
+++ b/documentation/docs/graphql/authorization.mdx
@@ -246,8 +246,8 @@ For example you could define the subtasks with the `auth` option, only allowing 
 
 ### Custom Authorizer
 
-When you need more control over authorization you can create a custom `Authorizer`. You may want to use a custom
-`Authorizer` if you need to use additional services to do authorization for a DTO.
+When you need more control over authorization you can create a `CustomAuthorizer`. You may want to use a
+`CustomAuthorizer` if you need to use additional services to do authorization for a DTO.
 
 The `CustomAuthorizer` interface ensures two methods:
 
@@ -409,17 +409,17 @@ If you want to use the CustomAuthorizer directly, inject it with `@InjectCustomA
 Sometimes it might be necessary to perform different authorization based on the kind of operation an user wants to execute.
 E.g. some users could be allowed to read all todo items but only update/delete their own.
 
-In this case we can make use of the second parameter of the `authorize` function in our custom `Authorizer` or the one passed to the `@Authorizer` decorator which gets passed additional `AuthorizationContext` such as the name of the operation that should be authorized:
+In this case we can make use of the second parameter of the `authorize` function in our `CustomAuthorizer` or the one passed to the `@Authorizer` decorator which gets passed additional `AuthorizationContext` such as the name of the operation that should be authorized:
 
 ```ts title='sub-task/sub-task.authorizer.ts'
 import { Injectable } from '@nestjs/common';
-import { Authorizer } from '@nestjs-query/query-graphql';
+import { CustomAuthorizer } from '@nestjs-query/query-graphql';
 import { Filter } from '@nestjs-query/core';
 import { UserContext } from '../auth/auth.interfaces';
 import { SubTaskDTO } from './dto/sub-task.dto';
 
 @Injectable()
-export class SubTaskAuthorizer implements Authorizer<SubTaskDTO> {
+export class SubTaskAuthorizer implements CustomAuthorizer<SubTaskDTO> {
   authorize(context: UserContext, authorizationContext?: AuthorizationContext): Promise<Filter<SubTaskDTO>> {
     if (authorizationContext?.readonly) {
       return Promise.resolve({});
@@ -463,7 +463,7 @@ interface AuthorizationContext {
 }
 ```
 
-This context is automatially created for you when using the built-in resolvers.
+This context is automatically created for you when using the built-in resolvers.
 If you authorize custom methods by using the `@AuthorizerFilter()`, you should pass the context as argument to the decorator:
 
 ```ts

--- a/packages/query-graphql/__tests__/auth/default-crud-auth.service.spec.ts
+++ b/packages/query-graphql/__tests__/auth/default-crud-auth.service.spec.ts
@@ -3,7 +3,13 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { Filter } from '@nestjs-query/core';
 import { Injectable } from '@nestjs/common';
 import { Authorizer, Relation, Authorize, UnPagedRelation } from '../../src';
-import { AuthorizationContext, OperationGroup, getAuthorizerToken } from '../../src/auth';
+import {
+  AuthorizationContext,
+  OperationGroup,
+  getAuthorizerToken,
+  getCustomAuthorizerToken,
+  CustomAuthorizer,
+} from '../../src/auth';
 import { createAuthorizerProviders } from '../../src/providers';
 
 describe('createDefaultAuthorizer', () => {
@@ -15,12 +21,12 @@ describe('createDefaultAuthorizer', () => {
   }
 
   @Injectable()
-  class RelationAuthorizer implements Authorizer<RelationWithAuthorizer> {
+  class RelationAuthorizer implements CustomAuthorizer<RelationWithAuthorizer> {
     authorize(context: UserContext): Promise<Filter<RelationWithAuthorizer>> {
       return Promise.resolve({ authorizerOwnerId: { eq: context.user.id } });
     }
 
-    authorizeRelation(): Promise<Filter<unknown>> {
+    authorizeRelation(): Promise<Filter<unknown> | undefined> {
       return Promise.reject(new Error('should not have called'));
     }
   }
@@ -30,7 +36,11 @@ describe('createDefaultAuthorizer', () => {
     authorizerOwnerId!: number;
   }
 
-  @Authorize({ authorize: (ctx: UserContext) => ({ decoratorOwnerId: { eq: ctx.user.id } }) })
+  @Authorize({
+    authorize: (ctx: UserContext) => ({
+      decoratorOwnerId: { eq: ctx.user.id },
+    }),
+  })
   class TestDecoratorRelation {
     decoratorOwnerId!: number;
   }
@@ -59,6 +69,32 @@ describe('createDefaultAuthorizer', () => {
     ownerId!: number;
   }
 
+  @Injectable()
+  class TestWithAuthorizerAuthorizer implements CustomAuthorizer<TestWithAuthorizerDTO> {
+    authorize(context: UserContext): Promise<Filter<TestWithAuthorizerDTO>> {
+      return Promise.resolve({ ownerId: { eq: context.user.id } });
+    }
+
+    authorizeRelation(): Promise<Filter<unknown> | undefined> {
+      return Promise.resolve(undefined);
+    }
+  }
+
+  @Authorize(TestWithAuthorizerAuthorizer)
+  @Relation('relations', () => TestRelation, {
+    auth: {
+      authorize: (ctx: UserContext, authorizationContext?: AuthorizationContext) =>
+        authorizationContext?.operationName === 'other'
+          ? { relationOwnerId: { neq: ctx.user.id } }
+          : { relationOwnerId: { eq: ctx.user.id } },
+    },
+  })
+  @UnPagedRelation('unPagedDecoratorRelations', () => TestDecoratorRelation)
+  @Relation('authorizerRelation', () => RelationWithAuthorizer)
+  class TestWithAuthorizerDTO {
+    ownerId!: number;
+  }
+
   beforeEach(async () => {
     testingModule = await Test.createTestingModule({
       providers: [
@@ -68,6 +104,7 @@ describe('createDefaultAuthorizer', () => {
           RelationWithAuthorizer,
           TestDTO,
           TestNoAuthDTO,
+          TestWithAuthorizerDTO,
         ]),
       ],
     }).compile();
@@ -79,7 +116,12 @@ describe('createDefaultAuthorizer', () => {
     const authorizer = testingModule.get<Authorizer<TestDTO>>(getAuthorizerToken(TestDTO));
     const filter = await authorizer.authorize(
       { user: { id: 2 } },
-      { operationName: 'queryMany', operationGroup: OperationGroup.READ, readonly: true, many: true },
+      {
+        operationName: 'queryMany',
+        operationGroup: OperationGroup.READ,
+        readonly: true,
+        many: true,
+      },
     );
     expect(filter).toEqual({ ownerId: { eq: 2 } });
   });
@@ -88,7 +130,12 @@ describe('createDefaultAuthorizer', () => {
     const authorizer = testingModule.get<Authorizer<TestDTO>>(getAuthorizerToken(TestDTO));
     const filter = await authorizer.authorize(
       { user: { id: 2 } },
-      { operationName: 'other', operationGroup: OperationGroup.READ, readonly: true, many: true },
+      {
+        operationName: 'other',
+        operationGroup: OperationGroup.READ,
+        readonly: true,
+        many: true,
+      },
     );
     expect(filter).toEqual({ ownerId: { neq: 2 } });
   });
@@ -97,7 +144,12 @@ describe('createDefaultAuthorizer', () => {
     const authorizer = testingModule.get<Authorizer<TestNoAuthDTO>>(getAuthorizerToken(TestNoAuthDTO));
     const filter = await authorizer.authorize(
       { user: { id: 2 } },
-      { operationName: 'queryMany', operationGroup: OperationGroup.READ, readonly: true, many: true },
+      {
+        operationName: 'queryMany',
+        operationGroup: OperationGroup.READ,
+        readonly: true,
+        many: true,
+      },
     );
     expect(filter).toEqual({});
   });
@@ -107,7 +159,12 @@ describe('createDefaultAuthorizer', () => {
     const filter = await authorizer.authorizeRelation(
       'unPagedDecoratorRelations',
       { user: { id: 2 } },
-      { operationName: 'queryRelation', operationGroup: OperationGroup.READ, readonly: true, many: true },
+      {
+        operationName: 'queryRelation',
+        operationGroup: OperationGroup.READ,
+        readonly: true,
+        many: true,
+      },
     );
     expect(filter).toEqual({ decoratorOwnerId: { eq: 2 } });
   });
@@ -117,7 +174,12 @@ describe('createDefaultAuthorizer', () => {
     const filter = await authorizer.authorizeRelation(
       'relations',
       { user: { id: 2 } },
-      { operationName: 'queryRelation', operationGroup: OperationGroup.READ, readonly: true, many: true },
+      {
+        operationName: 'queryRelation',
+        operationGroup: OperationGroup.READ,
+        readonly: true,
+        many: true,
+      },
     );
     expect(filter).toEqual({ relationOwnerId: { eq: 2 } });
   });
@@ -127,7 +189,12 @@ describe('createDefaultAuthorizer', () => {
     const filter = await authorizer.authorizeRelation(
       'relations',
       { user: { id: 2 } },
-      { operationName: 'other', operationGroup: OperationGroup.READ, readonly: true, many: true },
+      {
+        operationName: 'other',
+        operationGroup: OperationGroup.READ,
+        readonly: true,
+        many: true,
+      },
     );
     expect(filter).toEqual({ relationOwnerId: { neq: 2 } });
   });
@@ -137,7 +204,12 @@ describe('createDefaultAuthorizer', () => {
     const filter = await authorizer.authorizeRelation(
       'authorizerRelation',
       { user: { id: 2 } },
-      { operationName: 'queryRelation', operationGroup: OperationGroup.READ, readonly: true, many: true },
+      {
+        operationName: 'queryRelation',
+        operationGroup: OperationGroup.READ,
+        readonly: true,
+        many: true,
+      },
     );
     expect(filter).toEqual({ authorizerOwnerId: { eq: 2 } });
   });
@@ -147,8 +219,125 @@ describe('createDefaultAuthorizer', () => {
     const filter = await authorizer.authorizeRelation(
       'unknownRelations',
       { user: { id: 2 } },
-      { operationName: 'queryRelation', operationGroup: OperationGroup.READ, readonly: true, many: true },
+      {
+        operationName: 'queryRelation',
+        operationGroup: OperationGroup.READ,
+        readonly: true,
+        many: true,
+      },
     );
     expect(filter).toEqual({});
+  });
+
+  it('should call authorizeRelation of authorizer and fallback to authorize decorator', async () => {
+    const authorizer = testingModule.get<Authorizer<TestWithAuthorizerDTO>>(getAuthorizerToken(TestWithAuthorizerDTO));
+    jest.spyOn(authorizer, 'authorizeRelation');
+    const customAuthorizer = testingModule.get<CustomAuthorizer<TestWithAuthorizerDTO>>(
+      getCustomAuthorizerToken(TestWithAuthorizerDTO),
+    );
+    jest.spyOn(customAuthorizer, 'authorizeRelation');
+    expect(customAuthorizer).toBeDefined();
+    const filter = await authorizer.authorizeRelation(
+      'unPagedDecoratorRelations',
+      { user: { id: 2 } },
+      {
+        operationName: 'queryMany',
+        operationGroup: OperationGroup.READ,
+        readonly: true,
+        many: true,
+      },
+    );
+    expect(filter).toEqual({
+      decoratorOwnerId: { eq: 2 },
+    });
+    expect(customAuthorizer.authorizeRelation).toHaveBeenCalledWith(
+      'unPagedDecoratorRelations',
+      { user: { id: 2 } },
+      {
+        operationName: 'queryMany',
+        operationGroup: OperationGroup.READ,
+        readonly: true,
+        many: true,
+      },
+    );
+    expect(authorizer.authorizeRelation).toHaveBeenCalledWith(
+      'unPagedDecoratorRelations',
+      { user: { id: 2 } },
+      {
+        operationName: 'queryMany',
+        operationGroup: OperationGroup.READ,
+        readonly: true,
+        many: true,
+      },
+    );
+  });
+
+  it('should call authorizeRelation of authorizer and fallback to custom authorizer of relation', async () => {
+    const authorizer = testingModule.get<Authorizer<TestWithAuthorizerDTO>>(getAuthorizerToken(TestWithAuthorizerDTO));
+    jest.spyOn(authorizer, 'authorizeRelation');
+    const customAuthorizer = testingModule.get<CustomAuthorizer<TestWithAuthorizerDTO>>(
+      getCustomAuthorizerToken(TestWithAuthorizerDTO),
+    );
+    jest.spyOn(customAuthorizer, 'authorizeRelation');
+    expect(customAuthorizer).toBeDefined();
+    const relationAuthorizer = testingModule.get<Authorizer<RelationWithAuthorizer>>(
+      getAuthorizerToken(RelationWithAuthorizer),
+    );
+    jest.spyOn(relationAuthorizer, 'authorize');
+    const customRelationAuthorizer = testingModule.get<CustomAuthorizer<RelationWithAuthorizer>>(
+      getCustomAuthorizerToken(RelationWithAuthorizer),
+    );
+    jest.spyOn(customRelationAuthorizer, 'authorize');
+    const filter = await authorizer.authorizeRelation(
+      'authorizerRelation',
+      { user: { id: 2 } },
+      {
+        operationName: 'queryRelation',
+        operationGroup: OperationGroup.READ,
+        readonly: true,
+        many: true,
+      },
+    );
+    expect(filter).toEqual({
+      authorizerOwnerId: { eq: 2 },
+    });
+    expect(customAuthorizer.authorizeRelation).toHaveBeenCalledWith(
+      'authorizerRelation',
+      { user: { id: 2 } },
+      {
+        operationName: 'queryRelation',
+        operationGroup: OperationGroup.READ,
+        readonly: true,
+        many: true,
+      },
+    );
+    expect(authorizer.authorizeRelation).toHaveBeenCalledWith(
+      'authorizerRelation',
+      { user: { id: 2 } },
+      {
+        operationName: 'queryRelation',
+        operationGroup: OperationGroup.READ,
+        readonly: true,
+        many: true,
+      },
+    );
+    expect(relationAuthorizer.authorize).toHaveBeenCalledWith(
+      { user: { id: 2 } },
+      {
+        operationName: 'queryRelation',
+        operationGroup: OperationGroup.READ,
+        readonly: true,
+        many: true,
+      },
+    );
+    expect(customRelationAuthorizer.authorize).toHaveBeenCalledWith(
+      { user: { id: 2 } },
+      {
+        operationName: 'queryRelation',
+        operationGroup: OperationGroup.READ,
+        readonly: true,
+        many: true,
+      },
+    );
   });
 });

--- a/packages/query-graphql/__tests__/auth/default-crud-auth.service.spec.ts
+++ b/packages/query-graphql/__tests__/auth/default-crud-auth.service.spec.ts
@@ -250,6 +250,7 @@ describe('createDefaultAuthorizer', () => {
     expect(filter).toEqual({
       decoratorOwnerId: { eq: 2 },
     });
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(customAuthorizer.authorizeRelation).toHaveBeenCalledWith(
       'unPagedDecoratorRelations',
       { user: { id: 2 } },
@@ -260,6 +261,7 @@ describe('createDefaultAuthorizer', () => {
         many: true,
       },
     );
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(authorizer.authorizeRelation).toHaveBeenCalledWith(
       'unPagedDecoratorRelations',
       { user: { id: 2 } },
@@ -301,6 +303,7 @@ describe('createDefaultAuthorizer', () => {
     expect(filter).toEqual({
       authorizerOwnerId: { eq: 2 },
     });
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(customAuthorizer.authorizeRelation).toHaveBeenCalledWith(
       'authorizerRelation',
       { user: { id: 2 } },
@@ -311,6 +314,7 @@ describe('createDefaultAuthorizer', () => {
         many: true,
       },
     );
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(authorizer.authorizeRelation).toHaveBeenCalledWith(
       'authorizerRelation',
       { user: { id: 2 } },
@@ -321,6 +325,7 @@ describe('createDefaultAuthorizer', () => {
         many: true,
       },
     );
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(relationAuthorizer.authorize).toHaveBeenCalledWith(
       { user: { id: 2 } },
       {
@@ -330,6 +335,7 @@ describe('createDefaultAuthorizer', () => {
         many: true,
       },
     );
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(customRelationAuthorizer.authorize).toHaveBeenCalledWith(
       { user: { id: 2 } },
       {

--- a/packages/query-graphql/src/auth/authorizer.ts
+++ b/packages/query-graphql/src/auth/authorizer.ts
@@ -22,7 +22,19 @@ export interface AuthorizationContext {
   readonly many: boolean;
 }
 
-export interface Authorizer<DTO> {
+export interface CustomAuthorizer<DTO> {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types,@typescript-eslint/no-explicit-any
+  authorize(context: any, authorizerContext: AuthorizationContext): Promise<Filter<DTO>>;
+
+  authorizeRelation?(
+    relationName: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    context: any,
+    authorizerContext: AuthorizationContext,
+  ): Promise<Filter<unknown> | undefined>;
+}
+
+export interface Authorizer<DTO> extends CustomAuthorizer<DTO> {
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types,@typescript-eslint/no-explicit-any
   authorize(context: any, authorizerContext: AuthorizationContext): Promise<Filter<DTO>>;
 
@@ -31,5 +43,5 @@ export interface Authorizer<DTO> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     context: any,
     authorizerContext: AuthorizationContext,
-  ): Promise<Filter<unknown>>;
+  ): Promise<Filter<unknown | undefined>>;
 }

--- a/packages/query-graphql/src/auth/default-crud.authorizer.ts
+++ b/packages/query-graphql/src/auth/default-crud.authorizer.ts
@@ -1,10 +1,10 @@
 import { ModuleRef } from '@nestjs/core';
 import { Class, Filter } from '@nestjs-query/core';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject, Optional } from '@nestjs/common';
 import { getAuthorizer, getRelations } from '../decorators';
-import { getAuthorizerToken } from './tokens';
+import { getAuthorizerToken, getCustomAuthorizerToken } from './tokens';
 import { ResolverRelation } from '../resolvers/relations';
-import { Authorizer, AuthorizationContext } from './authorizer';
+import { Authorizer, AuthorizationContext, CustomAuthorizer } from './authorizer';
 
 export interface AuthorizerOptions<DTO> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -23,28 +23,31 @@ const createRelationAuthorizer = (opts: AuthorizerOptions<unknown>): Authorizer<
 
 export function createDefaultAuthorizer<DTO>(
   DTOClass: Class<DTO>,
-  opts: AuthorizerOptions<DTO>,
+  opts?: CustomAuthorizer<DTO> | AuthorizerOptions<DTO>, // instance of class or authorizer options
 ): Class<Authorizer<DTO>> {
   @Injectable()
   class DefaultAuthorizer implements Authorizer<DTO> {
-    readonly authOptions: AuthorizerOptions<DTO> = opts;
+    readonly authOptions?: AuthorizerOptions<DTO> | CustomAuthorizer<DTO> = opts;
 
     readonly relationsAuthorizers: Map<string, Authorizer<unknown> | undefined>;
 
-    constructor(moduleRef: ModuleRef) {
+    private readonly relations: Map<string, ResolverRelation<unknown>>;
+
+    constructor(
+      private readonly moduleRef: ModuleRef,
+      @Optional() @Inject(getCustomAuthorizerToken(DTOClass)) private readonly customAuthorizer?: CustomAuthorizer<DTO>,
+    ) {
       this.relationsAuthorizers = new Map<string, Authorizer<unknown> | undefined>();
-      this.relations.forEach((value, key) => {
-        if (value.auth) {
-          this.relationsAuthorizers.set(key, createRelationAuthorizer(value.auth));
-        } else if (getAuthorizer(value.DTO)) {
-          this.relationsAuthorizers.set(key, moduleRef.get(getAuthorizerToken(value.DTO), { strict: false }));
-        }
-      });
+      this.relations = this.getRelations();
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async authorize(context: any, authorizationContext: AuthorizationContext): Promise<Filter<DTO>> {
-      return this.authOptions?.authorize(context, authorizationContext) ?? {};
+      return (
+        this.customAuthorizer?.authorize(context, authorizationContext) ??
+        this.authOptions?.authorize(context, authorizationContext) ??
+        {}
+      );
     }
 
     async authorizeRelation(
@@ -53,10 +56,34 @@ export function createDefaultAuthorizer<DTO>(
       context: any,
       authorizationContext: AuthorizationContext,
     ): Promise<Filter<unknown>> {
+      if (this.customAuthorizer && typeof this.customAuthorizer.authorizeRelation === 'function') {
+        const filterFromCustomAuthorizer = await this.customAuthorizer.authorizeRelation(
+          relationName,
+          context,
+          authorizationContext,
+        );
+        if (filterFromCustomAuthorizer) return filterFromCustomAuthorizer;
+      }
+      this.addRelationAuthorizerIfNotExist(relationName);
       return this.relationsAuthorizers.get(relationName)?.authorize(context, authorizationContext) ?? {};
     }
 
-    private get relations(): Map<string, ResolverRelation<unknown>> {
+    private addRelationAuthorizerIfNotExist(relationName: string) {
+      if (!this.relationsAuthorizers.has(relationName)) {
+        const relation = this.relations.get(relationName);
+        if (!relation) return;
+        if (relation.auth) {
+          this.relationsAuthorizers.set(relationName, createRelationAuthorizer(relation.auth));
+        } else if (getAuthorizer(relation.DTO)) {
+          this.relationsAuthorizers.set(
+            relationName,
+            this.moduleRef.get(getAuthorizerToken(relation.DTO), { strict: false }),
+          );
+        }
+      }
+    }
+
+    private getRelations(): Map<string, ResolverRelation<unknown>> {
       const { many = {}, one = {} } = getRelations(DTOClass);
       const relationsMap = new Map<string, ResolverRelation<unknown>>();
       Object.keys(many).forEach((relation) => relationsMap.set(relation, many[relation]));

--- a/packages/query-graphql/src/auth/tokens.ts
+++ b/packages/query-graphql/src/auth/tokens.ts
@@ -1,3 +1,4 @@
 import { Class } from '@nestjs-query/core';
 
 export const getAuthorizerToken = <DTO>(DTOClass: Class<DTO>): string => `${DTOClass.name}Authorizer`;
+export const getCustomAuthorizerToken = <DTO>(DTOClass: Class<DTO>): string => `${DTOClass.name}CustomAuthorizer`;

--- a/packages/query-graphql/src/decorators/authorizer.decorator.ts
+++ b/packages/query-graphql/src/decorators/authorizer.decorator.ts
@@ -1,20 +1,22 @@
 import { Class, MetaValue, ValueReflector } from '@nestjs-query/core';
-import { AuthorizerOptions, createDefaultAuthorizer, Authorizer } from '../auth';
-import { AUTHORIZER_KEY } from './constants';
+import { AuthorizerOptions, createDefaultAuthorizer, Authorizer, CustomAuthorizer } from '../auth';
+import { AUTHORIZER_KEY, CUSTOM_AUTHORIZER_KEY } from './constants';
 
 const reflector = new ValueReflector(AUTHORIZER_KEY);
+const customAuthorizerReflector = new ValueReflector(CUSTOM_AUTHORIZER_KEY);
 export function Authorize<DTO>(
-  optsOrAuthorizerOrClass: Class<Authorizer<DTO>> | Authorizer<DTO> | AuthorizerOptions<DTO>,
+  optsOrAuthorizerOrClass: Class<CustomAuthorizer<DTO>> | CustomAuthorizer<DTO> | AuthorizerOptions<DTO>,
 ) {
   return (DTOClass: Class<DTO>): void => {
-    if ('authorize' in optsOrAuthorizerOrClass) {
-      if ('authorizeRelation' in optsOrAuthorizerOrClass) {
-        return reflector.set(DTOClass, optsOrAuthorizerOrClass);
-      }
-      return reflector.set(DTOClass, createDefaultAuthorizer(DTOClass, optsOrAuthorizerOrClass));
+    if (!('authorize' in optsOrAuthorizerOrClass)) {
+      // If the user provided a class, provide the custom authorizer and create a default authorizer that injects the custom authorizer
+      customAuthorizerReflector.set(DTOClass, optsOrAuthorizerOrClass);
+      return reflector.set(DTOClass, createDefaultAuthorizer(DTOClass));
     }
-    return reflector.set(DTOClass, optsOrAuthorizerOrClass);
+    return reflector.set(DTOClass, createDefaultAuthorizer(DTOClass, optsOrAuthorizerOrClass));
   };
 }
 
 export const getAuthorizer = <DTO>(DTOClass: Class<DTO>): MetaValue<Class<Authorizer<DTO>>> => reflector.get(DTOClass);
+export const getCustomAuthorizer = <DTO>(DTOClass: Class<DTO>): MetaValue<Class<CustomAuthorizer<DTO>>> =>
+  customAuthorizerReflector.get(DTOClass);

--- a/packages/query-graphql/src/decorators/constants.ts
+++ b/packages/query-graphql/src/decorators/constants.ts
@@ -4,6 +4,7 @@ export const RELATION_KEY = 'nestjs-query:relation';
 export const REFERENCE_KEY = 'nestjs-query:reference';
 
 export const AUTHORIZER_KEY = 'nestjs-query:authorizer';
+export const CUSTOM_AUTHORIZER_KEY = 'nestjs-query:custom-authorizer';
 
 export const KEY_SET_KEY = 'nestjs-query:key-set';
 

--- a/packages/query-graphql/src/decorators/index.ts
+++ b/packages/query-graphql/src/decorators/index.ts
@@ -31,6 +31,7 @@ export * from './decorator.utils';
 export * from './hook-args.decorator';
 export * from './authorizer.decorator';
 export * from './inject-authorizer.decorator';
+export * from './inject-custom-authorizer.decorator';
 export * from './key-set.decorator';
 export * from './authorize-filter.decorator';
 export * from './query-options.decorator';

--- a/packages/query-graphql/src/decorators/inject-custom-authorizer.decorator.ts
+++ b/packages/query-graphql/src/decorators/inject-custom-authorizer.decorator.ts
@@ -1,0 +1,6 @@
+import { Class } from '@nestjs-query/core';
+import { Inject } from '@nestjs/common';
+import { getCustomAuthorizerToken } from '../auth';
+
+export const InjectCustomAuthorizer = <DTO>(DTOClass: Class<DTO>): ParameterDecorator =>
+  Inject(getCustomAuthorizerToken(DTOClass));

--- a/packages/query-graphql/src/index.ts
+++ b/packages/query-graphql/src/index.ts
@@ -26,6 +26,7 @@ export {
   BeforeQueryMany,
   BeforeFindOne,
   InjectAuthorizer,
+  InjectCustomAuthorizer,
   Authorize,
   AuthorizerFilter,
   RelationAuthorizerFilter,
@@ -42,7 +43,7 @@ export { DTONamesOpts } from './common';
 export { NestjsQueryGraphQLModule } from './module';
 export { AutoResolverOpts } from './providers';
 export { pubSubToken, GraphQLPubSub } from './subscription';
-export { Authorizer, AuthorizerOptions, AuthorizationContext, OperationGroup } from './auth';
+export { Authorizer, CustomAuthorizer, AuthorizerOptions, AuthorizationContext, OperationGroup } from './auth';
 export {
   Hook,
   HookTypes,


### PR DESCRIPTION
Should fix
#1344 
#1339 
#1336 

This is non-breaking, since the old behaviour is preserved if the default `Authorizer` interface is used.