### PR TITLE
fix(query-typeorm): Fixed `deleteMany` throwing error when 

### DIFF
--- a/packages/query-typeorm/src/services/typeorm-query.service.ts
+++ b/packages/query-typeorm/src/services/typeorm-query.service.ts
@@ -226,7 +226,7 @@ export class TypeOrmQueryService<Entity>
    * @param filter - A `Filter` to find records to delete.
    */
   async deleteMany(filter: Filter<Entity>, opts?: DeleteManyOptions<Entity>): Promise<DeleteManyResponse> {
-    let deleteResult: DeleteResult;
+    let deleteResult = {} as DeleteResult;
     if (this.filterQueryBuilder.filterHasRelations(filter)) {
       const builder = this.filterQueryBuilder.select({ filter })
         .distinct(true);


### PR DESCRIPTION
`deleteMany` threw an error when the filter contained a relation, this will get all the ID's of the records with the correct filter and then delete them.