### PR TITLE
fix(core): Use correct return types for decorators

### DIFF
--- a/packages/core/src/decorators/inject-assembler-query-service.decorator.ts
+++ b/packages/core/src/decorators/inject-assembler-query-service.decorator.ts
@@ -12,4 +12,4 @@ export const InjectAssemblerQueryService = <
   UE = CE,
 >(
   AssemblerClass: Class<Assembler<DTO, Entity, C, CE, U, UE>>,
-): ParameterDecorator => Inject(getAssemblerQueryServiceToken(AssemblerClass));
+): ReturnType<typeof Inject> => Inject(getAssemblerQueryServiceToken(AssemblerClass));

--- a/packages/core/src/decorators/inject-query-service.decorator.ts
+++ b/packages/core/src/decorators/inject-query-service.decorator.ts
@@ -2,5 +2,5 @@ import { Inject } from '@nestjs/common';
 import { Class } from '../common';
 import { getQueryServiceToken } from './helpers';
 
-export const InjectQueryService = <DTO>(DTOClass: Class<DTO>): ParameterDecorator =>
+export const InjectQueryService = <DTO>(DTOClass: Class<DTO>): ReturnType<typeof Inject> =>
   Inject(getQueryServiceToken(DTOClass));


### PR DESCRIPTION
This updates makes sure both cases below works and does not give typescript errors

```
@Resolver()
export class CustomResolver {

  @InjectQueryService(TodoEntity)
  private readonly service: QueryService<TodoEntity>

  constructor(
    @InjectQueryService(TodoEntity) readonly service: QueryService<TodoEntity>
  ) {
  }

}
```