### PR TITLE
fix: #376 `AssemblerQueryService` not using `convertAsyncToDTO` for `findById`

### DIFF
--- a/packages/core/src/services/assembler-query.service.ts
+++ b/packages/core/src/services/assembler-query.service.ts
@@ -61,7 +61,7 @@ export class AssemblerQueryService<DTO, Entity, C = DeepPartial<DTO>, CE = DeepP
     if (!entity) {
       return undefined;
     }
-    return this.assembler.convertToDTO(entity);
+    return this.assembler.convertAsyncToDTO(Promise.resolve(entity));
   }
 
   getById(id: string | number, opts?: GetByIdOptions<DTO>): Promise<DTO> {


### PR DESCRIPTION
As described in https://github.com/doug-martin/nestjs-query/issues/376#issuecomment-808713112 the `AssemblerQueryService` appears to incorrectly use `convertToDTO` instead of `convertAsyncToDTO` for the `findById` method.