### PR TITLE
feat(core): Use convertAsyncToDto instead of convertToDto

### DIFF
--- a/packages/core/src/services/assembler-query.service.ts
+++ b/packages/core/src/services/assembler-query.service.ts
@@ -61,7 +61,7 @@ export class AssemblerQueryService<DTO, Entity, C = DeepPartial<DTO>, CE = DeepP
     if (!entity) {
       return undefined;
     }
-    return this.assembler.convertToDTO(entity);
+    return this.assembler.convertAsyncToDTO(Promise.resolve(entity));
   }
 
   getById(id: string | number, opts?: GetByIdOptions<DTO>): Promise<DTO> {


### PR DESCRIPTION
Hey! I've noticed an inconsistency between the getById and findById methods of the assembler query service. More specifically, one used `convertToDTO` and the other used `convertAsyncToDTO`. I hit this weirdness today since I had a custom assembler where I only defined the async version, and I was wondering why it wasn't working.

The change should be non breaking since the default convertAsyncToDTO calls convertToDTO internally.