### PR TITLE
docs() Fix typo in the code example

### DIFF
--- a/documentation/docs/persistence/sequelize/custom-service.md
+++ b/documentation/docs/persistence/sequelize/custom-service.md
@@ -17,7 +17,7 @@ export class TodoItemService extends SequelizeQueryService<TodoItemEntity> {
   }
 
   async markAllAsCompleted(): Promise<number> {
-    const entities = await this.query({ filter: { completed: { is: true } } });
+    const entities = await this.query({ filter: { completed: { is: false } } });
 
     const { updatedCount } = await this.updateMany(
       { completed: true }, // update


### PR DESCRIPTION
My assumption is that we should get all incomplete items and mark them as complete.